### PR TITLE
Fix clone tolerance error

### DIFF
--- a/src/optlang/cplex_interface.py
+++ b/src/optlang/cplex_interface.py
@@ -403,7 +403,10 @@ class Configuration(interface.MathematicalProgrammingConfiguration):
         self.qp_method = qp_method
         if "tolerances" in kwargs:
             for key, val in six.iteritems(kwargs["tolerances"]):
-                setattr(self.tolerances, key, val)
+                try:
+                    setattr(self.tolerances, key, val)
+                except AttributeError:
+                    pass
 
     @property
     def lp_method(self):

--- a/src/optlang/glpk_interface.py
+++ b/src/optlang/glpk_interface.py
@@ -391,7 +391,10 @@ class Configuration(interface.MathematicalProgrammingConfiguration):
         self.timeout = timeout
         if "tolerances" in kwargs:
             for key, val in six.iteritems(kwargs["tolerances"]):
-                setattr(self.tolerances, key, val)
+                try:
+                    setattr(self.tolerances, key, val)
+                except AttributeError:
+                    pass
 
     def __getstate__(self):
         return {'presolve': self.presolve,

--- a/src/optlang/gurobi_interface.py
+++ b/src/optlang/gurobi_interface.py
@@ -407,6 +407,12 @@ class Configuration(interface.MathematicalProgrammingConfiguration):
         self.qp_method = qp_method
         self.presolve = presolve
         self.timeout = timeout
+        if "tolerances" in kwargs:
+            for key, val in six.iteritems(kwargs["tolerances"]):
+                try:
+                    setattr(self.tolerances, key, val)
+                except AttributeError:
+                    pass
 
     @property
     def lp_method(self):

--- a/src/optlang/tests/test_change_solver.py
+++ b/src/optlang/tests/test_change_solver.py
@@ -74,7 +74,8 @@ try:
                 self.assertIs(constraint.__class__, cplex.Constraint)
 
         def test_clone_to_glpk(self):
-            glpk_model = glpk.Model.clone(self.model)
+            cplex_model = cplex.Model.clone(self.model)
+            glpk_model = glpk.Model.clone(cplex_model)
             self.assertEqual(glpk_model.__class__, glpk.Model)
             for variable in glpk_model.variables.values():
                 self.assertIs(variable.__class__, glpk.Variable)


### PR DESCRIPTION
Fixes the second error described in #220 

When cloning a model to another solver, the tolerances get set on the new model. However, when solvers have different tolerance parameters, this resulted in an AttributeError. This fix will ignore these AttributeErrors, and the result is that only the tolerance parameters that are shared between the old and new solver will get set on the cloned model.

A test for cloning models between solvers was also fixed to correctly test the case where a cplex model is cloned to a glpk model.
