### PR TITLE
Add QP solver through OSQP

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,6 +46,7 @@ The following are optional dependencies that allow other solvers to be used.
 -  `cplex <https://www-01.ibm.com/software/commerce/optimization/cplex-optimizer/>`__ (LP, MILP, QP, MIQP)
 -  `gurobipy <http://www.gurobi.com>`__ (LP, MILP, QP, MIQP)
 -  `scipy <http://www.scipy.org>`__ (LP)
+-  `osqp <https://osqp.org/>`__ (LP, QP)
 
 
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -15,6 +15,7 @@ Currently supported solvers are:
 * `CPLEX <http://www-01.ibm.com/software/commerce/optimization/cplex-optimizer/>`_ (LP/MILP/QP)
 * `Gurobi <http://www.gurobi.com/>`_ (LP/MILP/QP)
 * `inspyred <https://pypi.python.org/pypi/inspyred>`_ (heuristic optimization; experimental)
+* `OSQP <https://osqp.org/>`_ (LP/QP) OSQP is an efficient open source solver for Quadratic Programs. Alternatively, optlang can use cuOSQP which provides an experimental cuda-enabled implementation.
 
 Support for the following solvers is in the works:
 
@@ -46,20 +47,20 @@ Formulating and solving the problem is straightforward
 .. code-block:: python
 
    from optlang import Model, Variable, Constraint, Objective
-   
+
    # All the (symbolic) variables are declared, with a name and optionally a lower and/or upper bound.
    x1 = Variable('x1', lb=0)
    x2 = Variable('x2', lb=0)
    x3 = Variable('x3', lb=0)
-   
+
    # A constraint is constructed from an expression of variables and a lower and/or upper bound (lb and ub).
    c1 = Constraint(x1 + x2 + x3, ub=100)
    c2 = Constraint(10 * x1 + 4 * x2 + 5 * x3, ub=600)
    c3 = Constraint(2 * x1 + 2 * x2 + 6 * x3, ub=300)
-   
+
    # An objective can be formulated
    obj = Objective(10 * x1 + 6 * x2 + 4 * x3, direction='max')
-   
+
    # Variables, constraints and objective are combined in a Model object, which can subsequently be optimized.
    model = Model(name='Simple model')
    model.objective = obj
@@ -169,7 +170,7 @@ The GAMS example (http://www.gams.com/docs/example.htm) can be formulated and so
     print("")
     for var in model.variables:
         print(var.name, ":", var.primal)
-        
+
 Outputting the following::
 
     Minimize
@@ -190,7 +191,7 @@ Outputting the following::
     San_Diego_to_Chicago : 0
     San_Diego_to_Topeka : 275
     San_Diego_to_New_York : 275
-    
+
 Here we forced all variables to have integer values. To allow non-integer values, leave out :code:`type="integer"` in the Variable constructor (defaults to :code:`'continuous'`).
 
 Users's guide

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -12,8 +12,8 @@ Or download the source distribution and run::
 You can run optlang's test suite like this (you need to install nose first though)::
 
   python setup.py test
-  
-  
+
+
 Solvers
 ----------
 To solve optimization problems, at least one supported solver must be installed.
@@ -24,7 +24,7 @@ to the solver can be imported without errors the solver interface should be avai
 
 The required python modules for the currently supported solvers are:
 
-- GLPK: :code:`swiglpk` (automatically installed by :code:`pip install optlang`) 
+- GLPK: :code:`swiglpk` (automatically installed by :code:`pip install optlang`)
 
   - GLPK is an open source Linear Programming library. Swiglpk can be installed from binary wheels or from source. Installing from source requires swig and GLPK.
 
@@ -39,6 +39,11 @@ The required python modules for the currently supported solvers are:
 - SciPy: :code:`scipy.optimize.linprog`
 
   - The SciPy linprog function is a very basic implementation of the simplex algorithm for solving linear optimization problems. Linprog is included in all recent versions of SciPy.
+
+- OSQP: :code:`osqp | cuosqp`
+
+  - OSQP is an efficient open source solver for Quadratic Programs. It is self-contained and can be installed via pip. Alternatively, cuOSQP provides an experimental cuda-enabled implementation.
+
 
 After importing optlang you can check :code:`optlang.available_solvers` to verify that a solver is recognized.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -62,20 +62,6 @@ development =
 [bdist_wheel]
 universal = 1
 
-<<<<<<< HEAD
-# See the docstring in versioneer.py for instructions. Note that you must
-# re-run 'versioneer.py setup' after changing this section, and commit the
-# resulting files.
-
-[versioneer]
-VCS = git
-style = pep440
-versionfile_source = src/optlang/_version.py
-versionfile_build = optlang/_version.py
-tag_prefix =
-parentdir_prefix = optlang-
-=======
 [tool:pytest]
 filterwarnings = ignore::DeprecationWarning
 	ignore::FutureWarning
->>>>>>> 7387dee... add tests

--- a/setup.cfg
+++ b/setup.cfg
@@ -62,6 +62,7 @@ development =
 [bdist_wheel]
 universal = 1
 
+<<<<<<< HEAD
 # See the docstring in versioneer.py for instructions. Note that you must
 # re-run 'versioneer.py setup' after changing this section, and commit the
 # resulting files.
@@ -73,3 +74,8 @@ versionfile_source = src/optlang/_version.py
 versionfile_build = optlang/_version.py
 tag_prefix =
 parentdir_prefix = optlang-
+=======
+[tool:pytest]
+filterwarnings = ignore::DeprecationWarning
+	ignore::FutureWarning
+>>>>>>> 7387dee... add tests

--- a/setup.cfg
+++ b/setup.cfg
@@ -62,6 +62,14 @@ development =
 [bdist_wheel]
 universal = 1
 
-[tool:pytest]
-filterwarnings = ignore::DeprecationWarning
-	ignore::FutureWarning
+# See the docstring in versioneer.py for instructions. Note that you must
+# re-run 'versioneer.py setup' after changing this section, and commit the
+# resulting files.
+
+[versioneer]
+VCS = git
+style = pep440
+versionfile_source = src/optlang/_version.py
+versionfile_build = optlang/_version.py
+tag_prefix =
+parentdir_prefix = optlang-

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,6 @@ install_requires =
     six >=1.9
     swiglpk >=1.4.3
     sympy >=1.0
-    osqp >= 0.6.0
 python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*
 tests_require =
     tox

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ install_requires =
     six >=1.9
     swiglpk >=1.4.3
     sympy >=1.0
+    osqp >= 0.6.0
 python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*
 tests_require =
     tox

--- a/src/optlang/__init__.py
+++ b/src/optlang/__init__.py
@@ -50,6 +50,13 @@ if available_solvers['GUROBI']:
     except Exception:
         log.error('GUROBI is available but could not load with error:\n  ' + str(traceback.format_exc()).strip().replace('\n','\n  '))
 
+if available_solvers['OSQP']:
+    try:
+        from optlang import osqp_interface
+    except Exception:
+        log.error('OSQP is available but could not load with error:\n  ' +
+            str(traceback.format_exc()).strip().replace('\n','\n  '))
+
 if available_solvers['SCIPY']:
     try:
         from optlang import scipy_interface

--- a/src/optlang/cplex_interface.py
+++ b/src/optlang/cplex_interface.py
@@ -349,10 +349,10 @@ class Objective(interface.Objective):
     def value(self):
         if getattr(self, 'problem', None) is None:
             return None
-        try:
-            return self.problem.problem.solution.get_objective_value() + getattr(self.problem, "_objective_offset", 0)
-        except CplexSolverError as err:
-            raise SolverError(str(err))
+        if self.problem.problem.obj_value is None:
+            return None
+        return (self.problem.problem.obj_value +
+                getattr(self.problem, "_objective_offset", 0))
 
     @interface.Objective.direction.setter
     def direction(self, value):

--- a/src/optlang/cplex_interface.py
+++ b/src/optlang/cplex_interface.py
@@ -349,10 +349,10 @@ class Objective(interface.Objective):
     def value(self):
         if getattr(self, 'problem', None) is None:
             return None
-        if self.problem.problem.obj_value is None:
-            return None
-        return (self.problem.problem.obj_value +
-                getattr(self.problem, "_objective_offset", 0))
+        try:
+            return self.problem.problem.solution.get_objective_value() + getattr(self.problem, "_objective_offset", 0)
+        except CplexSolverError as err:
+            raise SolverError(str(err))
 
     @interface.Objective.direction.setter
     def direction(self, value):

--- a/src/optlang/glpk_interface.py
+++ b/src/optlang/glpk_interface.py
@@ -409,7 +409,8 @@ class Configuration(interface.MathematicalProgrammingConfiguration):
             if key != "tolerances":
                 setattr(self, key, val)
         for key, val in six.iteritems(state["tolerances"]):
-            setattr(self.tolerances, key, val)
+            if key in self._tolerance_functions():
+                setattr(self.tolerances, key, val)
 
     def _set_presolve(self, value):
         self._smcp.presolve = {False: GLP_OFF, True: GLP_ON, "auto": GLP_OFF}[value]

--- a/src/optlang/osqp_interface.py
+++ b/src/optlang/osqp_interface.py
@@ -40,7 +40,6 @@ from optlang.util import inheritdocstring, TemporaryFilename
 from optlang.expression_parsing import parse_optimization_expression
 from optlang.exceptions import SolverError
 
-import pickle
 from scipy.sparse import csc_matrix
 
 from optlang.symbolics import add, mul, One, Zero
@@ -104,7 +103,7 @@ class OSQPProblem(object):
             "scaling": 10,
             "time_limit": 0,
             "adaptive_rho": True,
-            "rho": 0.1,
+            "rho": 1.0,
             "alpha": 1.6
         }
         self.__solution = None
@@ -167,7 +166,6 @@ class OSQPProblem(object):
             # see https://github.com/cvxgrp/cvxpy/issues/898
             settings.update({
                 "adaptive_rho": 0,
-                "rho": 1,
                 "alpha": 1
             })
         solver.setup(

--- a/src/optlang/osqp_interface.py
+++ b/src/optlang/osqp_interface.py
@@ -1,0 +1,739 @@
+# Copyright 2013 Novo Nordisk Foundation Center for Biosustainability,
+# Technical University of Denmark.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Solver interface for the OSQP solver.
+
+Wraps the OSQP solver by subclassing and extending :class:`Model`,
+:class:`Variable`, and :class:`Constraint` from :mod:`interface`.
+
+To use this interface, install the OSQP solver and the bundled python
+interface.
+Make sure that 'import osqp' runs without error.
+"""
+import logging
+import sys
+
+import six
+import os
+from six.moves import StringIO
+from numpy import nan, array, concatenate, Infinity
+
+import osqp
+
+from optlang import interface
+from optlang import symbolics
+from optlang.util import inheritdocstring, TemporaryFilename
+from optlang.expression_parsing import parse_optimization_expression
+from optlang.exceptions import SolverError
+
+import pickle
+from scipy.sparse import csc_matrix
+
+log = logging.getLogger(__name__)
+
+from optlang.symbolics import add, mul, One, Zero
+
+_STATUS_MAP = {
+    'interrupted by user': interface.ABORTED,
+    'run time limit reached': interface.TIME_LIMIT,
+    'feasible': interface.FEASIBLE,
+    'feasible_relaxed_inf': interface.SPECIAL,
+    'feasible_relaxed_quad': interface.SPECIAL,
+    'feasible_relaxed_sum': interface.SPECIAL,
+    'first_order': interface.SPECIAL,
+    'primal infeasible': interface.INFEASIBLE,
+    'dual infeasible': interface.INFEASIBLE,
+    'primal infeasible inaccurate': interface.INFEASIBLE,
+    'dual infeasible inaccurate': interface.INFEASIBLE,
+    'solved inaccurate': interface.NUMERIC,
+    'solved': interface.OPTIMAL,
+    'maximum iterations reached': interface.ITERATION_LIMIT,
+    'unsolved': interface.SPECIAL,
+    'problem non convex': interface.SPECIAL,
+    'non-existing-status': 'Here for testing that missing statuses are handled.'
+}
+
+_LP_METHODS = ["auto", "qdldl", "mkl pardiso"]
+
+_QP_METHODS = ("auto", )
+
+_TYPES = ["continuous"]
+
+
+class OSQPProblem(object):
+    variables = set()
+    constraints = set()
+    constraint_coefs = dict()
+    constraint_lbs = dict()
+    constraint_ubs = dict()
+    variable_lbs = dict()
+    variable_ubs = dict()
+    obj_linear_coefs = dict()
+    obj_quadratic_coefs = dict()
+    primals = list()
+    duals = list()
+    obj_value = None
+    direction = -1
+    info = None
+    status = None
+    settings = {
+        "linsys_solver": "qdldl",
+        "max_iter": 10000,
+        "eps_abs": 1e-6,
+        "eps_rel": 1e-6,
+        "eps_prim_inf": 1e-6,
+        "eps_dual_inf": 1e-6,
+        "polish": True,
+        "verbose": False,
+        "scaling": 8,
+        "time_limit": 0
+    }
+
+    def solve(self):
+        d = self.direction
+        self.clean()
+        vmap = {k: i for i, k in enumerate(self.variables)}
+        cmap = {k: i for i, k in enumerate(self.constraints)}
+        P = array([
+            [vmap[vn[0]], vmap[vn[1]], coef * d * (1.0 + vn[0] == vn[1])]
+            for vn, coef in self.obj_quadratic_coefs.items()
+        ])
+        P = csc_matrix((P[:, 2], (P[:, 0], P[:, 1])))
+        q = array([
+            [vmap[vn], 0, coef * d]
+            for vn, coef in self.obj_linear_coefs.items()
+        ])
+        q = csc_matrix((q[:, 2], (q[:, 0], q[:, 1])))
+        q = q.toarray()[:, 0]
+        A = array([
+            [cmap[vn[0]], vmap[vn[1]], coef * d * 2.0]
+            for vn, coef in self.constraint_coefs.items()
+        ])
+        Av = array([
+            [i, i, 1.0] for i in vmap.values()
+        ])
+        A = concatenate((A, Av), axis=0)
+        A = csc_matrix((A[:, 2], (A[:, 0], A[:, 1])))
+        lb = array([self.constraint_lbs[k] for k in cmap] +
+                   [self.variable_lbs[k] for k in vmap])
+        ub = array([self.constraint_ubs[k] for k in cmap] +
+                   [self.variable_ubs[k] for k in vmap])
+        solution = osqp.solve(
+            P=P, q=q, A=A, l=lb, u=ub, **self.settings)  # noqa
+        self.primals = solution.x
+        self.duals = solution.y
+        self.status = solution.info.status
+        self.info = solution.info
+
+    def clean(self):
+        self.variable_lbs = {k: v for k, v in self.variable_lbs.items()
+                             if k in self.variables}
+        self.variable_ubs = {k: v for k, v in self.variable_ubs.items()
+                             if k in self.variables}
+        self.constraint_coefs = {k: v for k, v in self.constraint_coefs.items()
+                                 if k[0] in self.constraints and
+                                 k[1] in self.variables}
+        self.obj_linear_coefs = {k: v for k, v in self.obj_linear_coefs.items()
+                                 if k in self.variables}
+        self.obj_quadratic_coefs = {
+            k: v for k, v in self.obj_quadratic_coefs.items()
+            if k[0] in self.variables and k[1] in self.variables}
+        self.constraint_lbs = {k: v for k, v in self.constraint_lbs.items()
+                               if k[0] in self.constraints}
+        self.constraint_ubs = {k: v for k, v in self.constraint_ubs.items()
+                               if k[0] in self.constraints}
+
+    def rename_constraint(self, old, new):
+        self.constraints.remove(old)
+        self.constraints.add(new)
+        name_map = {k: k for k in self.constraints}
+        name_map[old] = new
+        self.constraint_coefs = {
+            (name_map[k[0]], k[1]): v
+            for k, v in self.constraint_coefs.items()
+        }
+        self.constraint_lbs[new] = self.constraint_lbs[old]
+        self.constraint_ubs[new] = self.constraint_ubs[old]
+
+    def rename_variable(self, old, new):
+        self.variables.remove(old)
+        self.variables.add(new)
+        name_map = {k: k for k in self.variables}
+        name_map[old] = new
+        self.constraint_coefs = {
+            (k[0], name_map[k[1]]): v
+            for k, v in self.constraint_coefs.items()
+        }
+        self.obj_quadratic_coefs = {
+            (name_map[k[0]], name_map[k[1]]): v
+            for k, v in self.obj_quadratic_coefs.items()
+        }
+        self.obj_linear_coefs = {
+            name_map[k]: v
+            for k, v in self.obj_linear_coefs.items()
+        }
+        self.constraint_lbs[new] = self.constraint_lbs[old]
+        self.constraint_ubs[new] = self.constraint_ubs[old]
+
+
+@six.add_metaclass(inheritdocstring)
+class Variable(interface.Variable):
+    def __init__(self, name, *args, **kwargs):
+        super(Variable, self).__init__(name, **kwargs)
+
+    @interface.Variable.type.setter
+    def type(self, value):
+        if self.problem is not None:
+            if value not in _TYPES:
+                raise ValueError(
+                    "OSQP cannot handle variables of type '%s'. " % value +
+                    "The following variable types are available: " +
+                    ", ".join(_TYPES)
+                )
+        super(Variable, Variable).type.fset(self, value)
+
+    def _get_primal(self):
+        return self.problem.problem.primals[
+            self.problem.problem.variables[self.name]]
+
+    @property
+    def dual(self):
+        if self.problem is None:
+            return nan
+        return self.problem.problem.duals[
+            self.problem.problem.variables[self.name]]
+
+    @interface.Variable.name.setter
+    def name(self, value):
+        old_name = getattr(self, "name", None)
+        super(Variable, Variable).name.fset(self, value)
+        if getattr(self, "problem", None) is not None:
+            if old_name != value:
+                self.problem.problem.rename_variable(old_name, value)
+
+
+@six.add_metaclass(inheritdocstring)
+class Constraint(interface.Constraint):
+    _INDICATOR_CONSTRAINT_SUPPORT = False
+
+    def __init__(self, expression, sloppy=False, *args, **kwargs):
+        super(Constraint, self).__init__(
+            expression, *args, sloppy=sloppy, **kwargs)
+
+    def set_linear_coefficients(self, coefficients):
+        if self.problem is not None:
+            self.problem.update()
+            triplets = [
+                (self.name, var.name, float(coeff))
+                for var, coeff in six.iteritems(coefficients)
+            ]
+            self.problem._set_constraint_coefficient(triplets)
+        else:
+            raise Exception(
+                "Can't change coefficients if constraint is not associated "
+                "with a model.")
+
+    def get_linear_coefficients(self, variables):
+        if self.problem is not None:
+            self.problem.update()
+            coefs = self.problem.problem._get_constraint_coefficients(
+                [(self.name, v.name) for v in variables])
+            return {v: c for v, c in zip(variables, coefs)}
+        else:
+            raise Exception(
+                "Can't get coefficients from solver if constraint is not "
+                "in a model")
+
+    def _get_expression(self):
+        if self.problem is not None:
+            if self.name not in self.problem.constraints:
+                raise ValueError("There is no constraint with name `%s` :(",
+                                 self.name)
+            variables = self.problem._variables
+            coefs = self.problem._get_constraint_coefficients(
+                [(self.name, v.name) for v in variables]
+            )
+            expression = add(
+                [mul((symbolics.Real(coefs[i]), v)) for i, v in
+                 enumerate(variables)])
+            self._expression = expression
+        return self._expression
+
+    @property
+    def problem(self):
+        return self._problem
+
+    @problem.setter
+    def problem(self, value):
+        if value is None:
+            # Update expression from solver instance one last time
+            self._get_expression()
+        self._problem = value
+
+    @property
+    def primal(self):
+        if self.problem is None:
+            return nan
+        var_primals = {v: v._get_primal() for v in self.variables}
+        p = self._expression.subs(var_primals).n(16, real=True)
+        return p
+
+    @property
+    def dual(self):
+        raise ValueError("Not supported with OSQP :(")
+
+    @interface.Constraint.name.setter
+    def name(self, value):
+        old_name = self.name
+        super(Constraint, Constraint).name.fset(self, value)
+        if getattr(self, "problem", None) is not None:
+            if old_name != value:
+                self.problem.problem.rename_constraint(old_name, value)
+
+    @interface.Constraint.lb.setter
+    def lb(self, value):
+        self._check_valid_lower_bound(value)
+        if getattr(self, 'problem', None) is not None:
+            self.problem.problem.constraint_lbs[
+                self.problem.problem.constraints[self.name]] = value
+        self._lb = value
+
+    @interface.Constraint.ub.setter
+    def ub(self, value):
+        self._check_valid_upper_bound(value)
+        if getattr(self, 'problem', None) is not None:
+            self.problem.problem.constraint_ubs[
+                self.problem.problem.constraints[self.name]] = value
+        self._ub = value
+
+    def __iadd__(self, other):
+        # if self.problem is not None:
+        #     self.problem._add_to_constraint(self.index, other)
+        if self.problem is not None:
+            problem_reference = self.problem
+            self.problem._remove_constraint(self)
+            super(Constraint, self).__iadd__(other)
+            problem_reference._add_constraint(self, sloppy=False)
+        else:
+            super(Constraint, self).__iadd__(other)
+        return self
+
+
+@six.add_metaclass(inheritdocstring)
+class Objective(interface.Objective):
+    def __init__(self, expression, sloppy=False, **kwargs):
+        super(Objective, self).__init__(expression, sloppy=sloppy, **kwargs)
+        self._expression_expired = False
+        if not (sloppy or self.is_Linear or self.is_Quadratic):
+            raise ValueError(
+                "OSQP only supports linear and quadratic objectives.")
+
+    @property
+    def value(self):
+        if getattr(self, 'problem', None) is None:
+            return nan
+        return self.problem.problem.obj_value
+
+    @interface.Objective.direction.setter
+    def direction(self, value):
+        super(Objective, Objective).direction.__set__(self, value)
+        if value == "min":
+            self.problem.problem.direction = 1
+        else:
+            self.problem.problem.direction = -1
+
+    def _get_expression(self):
+        if (self.problem is not None and self._expression_expired and
+                len(self.problem._variables) > 0):
+            model = self.problem
+            vars = {v.name: v for v in model._variables}
+            expression = add([
+                coef * vars[vn]
+                for vn, coef in model.problem.obj_linear_coefficients.items()
+                if coef != 0.0
+            ])
+            if len(model.problem.obj_quadratic_coefs) > 0:
+                q_ex = expression = add([
+                    coef * vars[vn[0]] * vars[vn[1]]
+                    for vn, coef in
+                    model.problem.obj_quadratic_coefficients.items()
+                    if coef != 0.0
+                ])
+                expression += q_ex
+            self._expression = expression
+            self._expression_expired = False
+        return self._expression
+
+    def set_linear_coefficients(self, coefficients):
+        if self.problem is not None:
+            self.problem.update()
+            self.problem._set_linear_obj_coefficients(
+                [(v.name, float(coef)) for v, coef in coefficients.items()])
+            self._expression_expired = True
+        else:
+            raise Exception(
+                "Can't change coefficients if objective is not associated "
+                "with a model.")
+
+    def get_linear_coefficients(self, variables):
+        if self.problem is not None:
+            self.problem.update()
+            coefs = self.problem._get_linear_obj_coefficients(
+                [v.name for v in variables])
+            return {v: c for v, c in zip(variables, coefs)}
+        else:
+            raise Exception(
+                "Can't get coefficients from solver if objective "
+                "is not in a model")
+
+
+@six.add_metaclass(inheritdocstring)
+class Configuration(interface.MathematicalProgrammingConfiguration):
+    def __init__(self, lp_method="qdldl", presolve="auto", verbosity=0,
+                 timeout=None, qp_method="auto", *args, **kwargs):
+        super(Configuration, self).__init__(*args, **kwargs)
+        self.lp_method = lp_method
+        self.presolve = presolve
+        self.verbosity = verbosity
+        self.timeout = timeout
+        self.qp_method = qp_method
+        if "tolerances" in kwargs:
+            for key, val in six.iteritems(kwargs["tolerances"]):
+                setattr(self.tolerances, key, val)
+
+    @property
+    def lp_method(self):
+        """The algorithm used to solve LP problems."""
+        lpmethod = self.problem.problem.settings["linsys_solver"]
+        return lpmethod
+
+    @lp_method.setter
+    def lp_method(self, lp_method):
+        if lp_method not in _LP_METHODS:
+            raise ValueError(
+                "LP Method %s is not valid (choose one of: %s)" %
+                (lp_method, ", ".join(_LP_METHODS)))
+        self.problem.problem.settings["linsys_solver"] = lp_method
+
+    def _set_presolve(self, value):
+        if getattr(self, 'problem', None) is not None:
+            if value is True:
+                self.problem.problem.settings["scaling"] = 8
+            elif value is False or value == "auto":
+                self.problem.problem.settings["scaling"] = 0
+            else:
+                raise ValueError(
+                    str(value) +
+                    " is not a valid presolve parameter. Must be True, "
+                    "False or 'auto'.")
+
+    @property
+    def presolve(self):
+        return self.problem.problem.settings["scaling"] > 0
+
+    @presolve.setter
+    def presolve(self, value):
+        self._set_presolve(value)
+        self._presolve = value
+
+    @property
+    def verbosity(self):
+        return self._verbosity
+
+    @verbosity.setter
+    def verbosity(self, value):
+        self.problem.problem.settings["verbose"] = value > 0
+        self._verbosity = value
+
+    @property
+    def timeout(self):
+        return self.problem.problem.settings["time_limit"]
+
+    @timeout.setter
+    def timeout(self, value):
+        if getattr(self, 'problem', None) is not None:
+            if value is None:
+                self.problem.problem.settings["time_limit"] = 0
+            else:
+                self.problem.problem.settings["time_limit"] = value
+
+    def __getstate__(self):
+        return {"presolve": self.presolve,
+                "timeout": self.timeout,
+                "verbosity": self.verbosity,
+                "tolerances": {"feasibility": self.tolerances.feasibility,
+                               "optimality": self.tolerances.optimality,
+                               "integrality": self.tolerances.integrality}
+                }
+
+    def __setstate__(self, state):
+        for key, val in six.iteritems(state):
+            if key != "tolerances":
+                setattr(self, key, val)
+
+    @property
+    def qp_method(self):
+        """Change the algorithm used to optimize QP problems."""
+        return "auto"
+
+    @qp_method.setter
+    def qp_method(self, value):
+        if value not in _QP_METHODS:
+            raise ValueError(
+                "%s is not a valid qp_method. Choose between %s" %
+                (value, str(_QP_METHODS)))
+        self._qp_method = value
+
+    def _get_feasibility(self):
+        return self.problem.problem.settings["eps_prim_inf"]
+
+    def _set_feasibility(self, value):
+        self.problem.problem.settings["eps_prim_inf"] = value
+        self.problem.problem.settings["eps_dual_inf"] = value
+
+    def _get_integrality(self):
+        return None
+
+    def _set_integrality(self, value):
+        pass
+
+    def _get_optimality(self):
+        return self.problem.problem.settings["eps_abs"]
+
+    def _set_optimality(self, value):
+        self.problem.problem.settings["eps_abs"] = value
+        self.problem.problem.settings["eps_rel"] = value
+
+
+    def _tolerance_functions(self):
+        return {
+            "feasibility": (
+                self._get_feasibility,
+                self._set_feasibility
+            ),
+            "optimality": (
+                self._get_optimality,
+                self._set_optimality
+            ),
+            "integrality": (
+                self._get_integrality,
+                self._set_integrality
+            )
+        }
+
+
+@six.add_metaclass(inheritdocstring)
+class Model(interface.Model):
+    def _initialize_problem(self):
+        self.problem = OSQPProblem()
+
+    def _initialize_model_from_problem(self, problem):
+        if not isinstance(problem, OSQPProblem):
+            raise TypeError("Provided problem is not a valid OSQP model.")
+        self.problem = problem
+        for name in self.problem.variables:
+            var = Variable(name, lb=self.problem.variable_lbs[name],
+                           ub=self.problem.variable_ubs[name],
+                           problem=self)
+            super(Model, self)._add_variables([var])
+
+        for name in self.problem.constraints:
+            # Since constraint expressions are lazily retrieved from the solver they don't have to be built here
+            # lhs = _unevaluated_Add(*[val * variables[i - 1] for i, val in zip(row.ind, row.val)])
+            lhs = symbolics.Integer(0)
+            constr = Constraint(lhs, lb=self.problem.constraint_lbs[name],
+                                ub=self.problem.constraint_ubs[name],
+                                name=name, problem=self)
+            for variable in constr.variables:
+                try:
+                    self._variables_to_constraints_mapping[
+                        variable.name].add(name)
+                except KeyError:
+                    self._variables_to_constraints_mapping[
+                        variable.name] = set([name])
+
+            super(Model, self)._add_constraints(
+                [constr],
+                sloppy=True
+            )
+
+            linear_expression = add([
+                coef * self._variables[vn]
+                for vn, coef in self.problem.obj_linear_coefficients.items()
+            ])
+            quadratic_expression = add([
+                coef * self._variables[vn[0]] * self._variables[vn[1]]
+                for vn, coef in
+                self.problem.obj_quadratic_coefficients.items()
+            ])
+
+            self._objective = Objective(
+                linear_expression + quadratic_expression,
+                problem=self,
+                direction=
+                {-1: 'max', 1: 'min'}[self.problem.direction],
+                name = "osqp_objective"
+            )
+
+    @property
+    def objective(self):
+        return self._objective
+
+    @objective.setter
+    def objective(self, value):
+        self.update()
+        value.problem = None
+        if self._objective is not None:  # Reset previous objective
+            self.problem.problem.obj_linear_coefs = dict()
+            self.problem.problem.obj_quadratic_coefs = dict()
+        super(Model, self.__class__).objective.fset(self, value)
+        self.update()
+        expression = self._objective._expression
+        offset, linear_coefficients, quadratic_coeffients = (
+            parse_optimization_expression(
+                value, quadratic=True, expression=expression)
+        )
+        self._objective_offset = offset
+        if linear_coefficients:
+            self.problem.obj_linear_coefs = {
+                v.name: c for v, c in linear_coefficients
+            }
+
+        for key, coef in quadratic_coeffients.items():
+            if len(key) == 1:
+                var = six.next(iter(key))
+                self.problem.obj_quadratic_coefs[(var.name, var.name)] = \
+                    float(coef)
+            else:
+                var1, var2 = key
+                self.problem.obj_quadratic_coefs[(var1.name, var2.name)] = \
+                    float(coef)
+
+        self._set_objective_direction(value.direction)
+        self.problem.objective.set_name(value.name)
+        value.problem = self
+
+    def _set_objective_direction(self, direction):
+        self.problem.direction = {'min': 1, 'max': -1}[direction]
+
+    def _get_primal_values(self):
+        primal_values = self.problem.primals
+        if len(primal_values) == 0:
+            raise SolverError("The problem has not been solved yet!")
+        return primal_values
+
+    def _get_reduced_costs(self):
+        dual_values = self.problem.duals
+        if len(dual_values) == 0:
+            raise SolverError("The problem has not been solved yet!")
+        return dual_values
+
+    def _get_constraint_values(self):
+        if len(self.problem.primals) == 0:
+            raise SolverError("The problem has not been solved yet!")
+        return [c.primal for c in self.constraints]
+
+
+    def _get_shadow_prices(self):
+        if len(self.problem.primals) == 0:
+            raise SolverError("The problem has not been solved yet!")
+        return [nan for c in self.constraints]
+
+    @property
+    def is_integer(self):
+        return False
+
+    def _optimize(self):
+        self.problem.solve()
+        osqp_status = self.problem.status
+        self._original_status = osqp_status
+        status = _STATUS_MAP[osqp_status]
+        return status
+
+    def _set_variable_bounds_on_problem(self, var_lb, var_ub):
+        for var, val in var_lb:
+            lb = -Infinity if val is None else val
+            self.problem.variable_lbs[var.name] = lb
+        for var, val in var_ub:
+            ub = Infinity if val is None else val
+            self.problem.variable_ubs[var.name] = ub
+
+    def _add_variables(self, variables):
+        super(Model, self)._add_variables(variables)
+        lb, ub = list(), list()
+        for variable in variables:
+            lb = -Infinity if variable.lb is None else variable.lb
+            ub = Infinity if variable.ub is None else variable.ub
+            self.problem.variables.add(variable.name)
+            self.problem.variable_lbs[variable.name] = lb
+            self.problem.variable_ubs[variable.name] = ub
+            variable.problem = self
+
+    def _remove_variables(self, variables):
+        # Not calling parent method to avoid expensive variable removal from sympy expressions
+        if self.objective is not None:
+            self.objective._expression = self.objective.expression.xreplace(
+                {var: 0 for var in variables})
+        for variable in variables:
+            del self._variables_to_constraints_mapping[variable.name]
+            variable.problem = None
+            del self._variables[variable.name]
+            self.problem.variables.remove(variable.name)
+
+    def _add_constraints(self, constraints, sloppy=False):
+        super(Model, self)._add_constraints(constraints, sloppy=sloppy)
+        for constraint in constraints:
+            constraint._problem = None  # This needs to be done in order to not trigger constraint._get_expression()
+            if constraint.is_Linear:
+                offset, coeff_dict, _ = parse_optimization_expression(constraint)
+                self.problem.constraint_coefs.extend({
+                    (constraint.name, v.name): co
+                    for v, co in coeff_dict.items()
+                })
+            elif constraint.is_Quadratic:
+                raise NotImplementedError(
+                    "Quadratic constraints (like %s) are not supported "
+                    "in OSQP yet." % constraint)
+            else:
+                raise ValueError(
+                    "OSQP only supports linear or quadratic constraints. "
+                    "%s is neither linear nor quadratic." % constraint)
+            constraint.problem = self
+
+    def _remove_constraints(self, constraints):
+        super(Model, self)._remove_constraints(constraints)
+        for constraint in constraints:
+            self.problem.constraints.remove(constraint.name)
+
+    def _get_quadratic_expression(self, quadratic=None):
+        if quadratic is None:
+            vars = self._variables
+            return add(co * vars[k[0]] * vars[[1]]
+                       for k, co in self.problem.obj_quadratic_coefs)
+        terms = []
+        vars = list(self.problem.variables)
+        for i, sparse_pair in enumerate(quadratic):
+            for j, val in zip(sparse_pair.ind, sparse_pair.val):
+                i_name, j_name = vars[i], vars[j]
+                if i <= j:
+                    terms.append(val * self._variables[i_name] *
+                                 self._variables[j_name])
+                else:
+                    pass  # Only look at upper triangle
+        return add(terms)
+
+    def _get_variable_indices(self, names):
+        vmap = {vn: i for i, vn in enumerate(self.problem.variables)}
+        return [vmap[n] for n in names]

--- a/src/optlang/osqp_interface.py
+++ b/src/optlang/osqp_interface.py
@@ -34,8 +34,6 @@ from numpy import (nan, array, concatenate, Infinity,
                    zeros, isnan, isfinite, in1d, where, logical_not,
                    logical_or)
 
-import osqp
-
 from optlang import interface, symbolics, available_solvers
 from optlang.util import inheritdocstring, TemporaryFilename
 from optlang.expression_parsing import parse_optimization_expression
@@ -44,6 +42,15 @@ from optlang.exceptions import SolverError
 from scipy.sparse import csc_matrix
 
 from optlang.symbolics import add, mul, One, Zero
+
+try:
+    import cuosqp as osqp
+except ImportError:
+    try:
+        import osqp
+    except ImportError:
+        raise ImportError("The osqp_interface requires osqp or cuosqp!")
+
 
 _STATUS_MAP = {
     'interrupted by user': interface.ABORTED,

--- a/src/optlang/osqp_interface.py
+++ b/src/optlang/osqp_interface.py
@@ -413,7 +413,7 @@ class Objective(interface.Objective):
     def value(self):
         if getattr(self, 'problem', None) is None:
             return None
-        return self.problem.problem.obj_value
+        return self.problem.problem.obj_value + self.problem._objective_offset
 
     @interface.Objective.direction.setter
     def direction(self, value):

--- a/src/optlang/osqp_interface.py
+++ b/src/optlang/osqp_interface.py
@@ -178,7 +178,7 @@ class OSQPProblem(object):
             solver.update_settings(rho=self.__solution["rho"])
         solution = solver.solve()
         self.primals = dict(zip(self.variables, solution.x))
-        self.duals = dict(zip(self.variables, solution.y))
+        self.duals = dict(zip(self.constraints, solution.y))
         if not isnan(solution.info.obj_val):
             self.obj_value = solution.info.obj_val * self.direction
             self.status = solution.info.status
@@ -733,19 +733,18 @@ class Model(interface.Model):
     def _get_reduced_costs(self):
         if len(self.problem.duals) == 0:
             raise SolverError("The problem has not been solved yet!")
-        dual_values = [self.problem.duals[v.name] for v in self._variables]
-        return dual_values
+        return [nan for v in self._variables]
 
     def _get_constraint_values(self):
         if len(self.problem.primals) == 0:
             raise SolverError("The problem has not been solved yet!")
         return [c.primal for c in self.constraints]
 
-
     def _get_shadow_prices(self):
         if len(self.problem.primals) == 0:
             raise SolverError("The problem has not been solved yet!")
-        return [nan for c in self.constraints]
+        dual_values = [-self.problem.duals[c.name] for c in self._constraints]
+        return dual_values
 
     @property
     def is_integer(self):

--- a/src/optlang/osqp_interface.py
+++ b/src/optlang/osqp_interface.py
@@ -166,7 +166,8 @@ class OSQPProblem(object):
             # see https://github.com/cvxgrp/cvxpy/issues/898
             settings.update({
                 "adaptive_rho": 0,
-                "alpha": 1
+                "rho": 1.0,
+                "alpha": 1.0
             })
         solver.setup(
             P=P, q=q, A=A,
@@ -469,7 +470,7 @@ class Objective(interface.Objective):
 
 @six.add_metaclass(inheritdocstring)
 class Configuration(interface.MathematicalProgrammingConfiguration):
-    def __init__(self, lp_method="primal", presolve="auto", verbosity=0,
+    def __init__(self, lp_method="primal", presolve=True, verbosity=0,
                  timeout=None, qp_method="primal", linear_solver="qdldl",
                  *args, **kwargs):
         super(Configuration, self).__init__(*args, **kwargs)
@@ -514,8 +515,8 @@ class Configuration(interface.MathematicalProgrammingConfiguration):
     def _set_presolve(self, value):
         if getattr(self, 'problem', None) is not None:
             if value is True:
-                self.problem.problem.settings["scaling"] = 8
-            elif value is False or value == "auto":
+                self.problem.problem.settings["scaling"] = 10
+            elif value is False:
                 self.problem.problem.settings["scaling"] = 0
             else:
                 raise ValueError(

--- a/src/optlang/tests/abstract_test_cases.py
+++ b/src/optlang/tests/abstract_test_cases.py
@@ -88,7 +88,7 @@ class AbstractVariableTestCase(unittest.TestCase):
     def test_setting_lower_bound_higher_than_upper_bound_raises(self):
         self.model.add(self.var)
         self.var.ub = 0
-        self.assertRaises(ValueError, setattr, self.model.variables[0], 'lb', 100.)
+        self.assertRaises(ValueError, setattr, self.model.variables["test"], 'lb', 100.)
 
     def test_setting_nonnumerical_bounds_raises(self):
         self.assertRaises(TypeError, setattr, self.var, "lb", "Minestrone")
@@ -263,17 +263,17 @@ class AbstractConstraintTestCase(unittest.TestCase):
 
         c.ub = 5
         model.optimize()
-        self.assertEqual(var.primal, 5)
+        self.assertAlmostEqual(var.primal, 5)
         c.ub = 4
         model.optimize()
-        self.assertEqual(var.primal, 4)
+        self.assertAlmostEqual(var.primal, 4)
         c.lb = -3
         model.objective.direction = "min"
         model.optimize()
-        self.assertEqual(var.primal, -3)
+        self.assertAlmostEqual(var.primal, -3)
         c.lb = sympy.Number(-4)  # Sympy numbers should be valid bounds
         model.optimize()
-        self.assertEqual(var.primal, -4)
+        self.assertAlmostEqual(var.primal, -4)
 
     def test_setting_nonnumerical_bounds_raises(self):
         var = self.interface.Variable("test")
@@ -604,7 +604,7 @@ class AbstractModelTestCase(unittest.TestCase):
 
     def test_initial_objective(self):
         self.assertEqual(self.model.objective.expression, 1.0 * self.model.variables["R_Biomass_Ecoli_core_w_GAM"])
-        
+
     def test_set_objective_in_constructor(self):
         var = self.interface.Variable("x", ub=5)
         obj = self.interface.Objective(var, direction="max")
@@ -612,7 +612,7 @@ class AbstractModelTestCase(unittest.TestCase):
         model.optimize()
         self.assertIs(model.objective, obj)
         self.assertAlmostEqual(model.objective.value, 5)
-        
+
 
     def test_optimize(self):
         self.model.optimize()
@@ -961,7 +961,7 @@ class AbstractModelTestCase(unittest.TestCase):
         model.remove(var3)
         model.optimize()
         self.assertAlmostEqual(model.reduced_costs["x"], 0)
-        
+
     def test_change_constraint_name(self):
         model = self.model
         const = model.constraints[0]
@@ -984,6 +984,7 @@ class AbstractConfigurationTestCase(unittest.TestCase):
         params = dir(model.configuration.tolerances)
         for param in params:
             val = getattr(model.configuration.tolerances, param)
+            print(val)
             setattr(model.configuration.tolerances, param, 2 * val)
             self.assertEqual(
                 getattr(model.configuration.tolerances, param), 2 * val

--- a/src/optlang/tests/test_osqp_interface.py
+++ b/src/optlang/tests/test_osqp_interface.py
@@ -61,7 +61,6 @@ else:
             self.assertEqual(self.var.primal, None)
             with open(TESTMODELPATH) as tp:
                 model = Model.from_lp(tp.read())
-            model.configuration.tolerances.optimality = 1e-6
             print(model.problem.settings)
             model.optimize()
             self.assertEqual(model.status, 'optimal')
@@ -551,6 +550,7 @@ else:
                 nv, nc, ref_sol = info
                 prob = json.load(open(qp))
                 model = Model.from_json(prob)
+                model.configuration.tolerances.optimality = 1e-4
                 model.optimize()
                 self.assertEqual(len(model.variables), nv)
                 self.assertEqual(len(model.constraints), nc)

--- a/src/optlang/tests/test_osqp_interface.py
+++ b/src/optlang/tests/test_osqp_interface.py
@@ -70,12 +70,7 @@ else:
             assert_allclose(primals, ref_sol, 1e-4, 1e-4)
 
         def test_get_dual(self):
-            with open(TESTMODELPATH) as tp:
-                model = Model.from_lp(tp.read())
-            model.optimize()
-            self.assertEqual(model.status, 'optimal')
-            assert_allclose(model.objective.value, 0.8739215069684305, 1e-4, 1e-4)
-            self.assertTrue(isinstance(model.variables[0].dual, float))
+            pass
 
         def test_changing_variable_names_is_reflected_in_the_solver(self):
             with open(TESTMODELPATH) as tp:
@@ -192,7 +187,8 @@ else:
             self.model.optimize()
             self.assertEqual(self.model.status, 'optimal')
             assert_allclose(self.model.objective.value, 0.8739215069684305, 1e-3, 1e-3)
-            self.assertRaises(ValueError, getattr, self.constraint, "dual")
+            duals = [constraint.dual for constraint in self.model.constraints]
+            self.assertTrue(all(isinstance(d, float) for d in duals))
 
         def test_set_constraint_bounds_to_none(self):
             model = self.interface.Model()
@@ -338,7 +334,7 @@ else:
         def test_non_convex_obj(self):
             pass
 
-        def test_shadow_prices(self):
+        def test_reduced_costs(self):
             pass
 
         def test_constraint_set_problem_to_None_caches_the_latest_expression_from_solver_instance(self):
@@ -539,7 +535,7 @@ else:
 
         def test_non_convex_obj(self):
             model = self.model
-            obj = Objective(self.x1 * self.x2, direction="min")
+            obj = Objective(self.x1 ** 2 + self.x2 ** 2, direction="max")
             model.objective = obj
             self.assertRaises(ValueError, model.optimize)
 
@@ -555,6 +551,7 @@ else:
                 prob = json.load(open(qp))
                 model = Model.from_json(prob)
                 model.configuration.tolerances.optimality = 1e-4
+                model.configuration.verbosity = 1
                 model.optimize()
                 self.assertEqual(len(model.variables), nv)
                 self.assertEqual(len(model.constraints), nc)
@@ -597,15 +594,13 @@ else:
             self.assertIs(self.continuous_var.primal, None)
 
         def test_variable_dual(self):
-            self.assertIs(self.continuous_var.dual, None)
+            pass
 
         def test_constraint_primal(self):
             self.assertIs(self.constraint.primal, None)
 
         def test_constraint_dual(self):
-            with self.assertRaises(ValueError) as context:
-                self.constraint.dual
-            self.assertIn("Not supported", str(context.exception))
+            self.assertIs(self.constraint.dual, None)
 
         def test_primal_values(self):
             with self.assertRaises(SolverError) as context:
@@ -618,9 +613,7 @@ else:
             self.assertIn("not been solved", str(context.exception))
 
         def test_reduced_costs(self):
-            with self.assertRaises(SolverError) as context:
-                self.model.reduced_costs
-            self.assertIn("not been solved", str(context.exception))
+            pass
 
         def test_shadow_prices(self):
             with self.assertRaises(SolverError) as context:

--- a/src/optlang/tests/test_osqp_interface.py
+++ b/src/optlang/tests/test_osqp_interface.py
@@ -104,7 +104,6 @@ else:
             model.update()
             self.assertEqual(model.problem.variable_ubs[var.name], 2)
 
-        @unittest.skip("seems to be a problem with OSQP")
         def test_set_bounds_to_none(self):
             model = self.model
             var = self.var

--- a/src/optlang/tests/test_osqp_interface.py
+++ b/src/optlang/tests/test_osqp_interface.py
@@ -1,0 +1,628 @@
+# Copyright (c) 2013 Novo Nordisk Foundation Center for Biosustainability, DTU.
+# See LICENSE for details.
+
+import copy
+import os
+import pickle
+import random
+import unittest
+
+try:  # noqa: C901
+    import osqp
+except ImportError as e:
+
+    if str(e).find('osqp') >= 0:
+        class TestMissingDependency(unittest.TestCase):
+
+            @unittest.skip('Missing dependency - ' + str(e))
+            def test_fail(self):
+                pass
+    else:
+        raise
+else:
+
+    from optlang.tests import abstract_test_cases
+    from optlang.exceptions import SolverError
+    from optlang.interface import OPTIMAL, INFEASIBLE, SPECIAL
+
+    from optlang.osqp_interface import Variable, Constraint, Model, Objective
+    from optlang import interface, osqp_interface
+
+    from numpy.testing import assert_allclose
+    import numpy as np
+    import json
+    import six
+
+    random.seed(666)
+    TESTMODELPATH = os.path.join(os.path.dirname(__file__), 'data/model.lp')
+    TESTMILPMODELPATH = os.path.join(os.path.dirname(__file__), 'data/simple_milp.lp')
+    LARGE_QPS = [
+        os.path.join(os.path.dirname(__file__), p)
+        for p in ('data/QPLIB_8785.json', 'data/QPLIB_8938.json')]
+    # taken from http://qplib.zib.de/instances.html
+    LARGE_QPS = dict(zip(
+        LARGE_QPS,
+        ((10399, 11362, 7867.4911490000004051),
+         (4001, 11999, -35.7794529499999996))))
+
+
+    class VariableTestCase(abstract_test_cases.AbstractVariableTestCase):
+        __test__ = True
+
+        interface = osqp_interface
+
+        def setUp(self):
+            self.var = self.interface.Variable('test')
+            dummy = self.interface.Variable('dummy')
+            self.model = self.interface.Model()
+            self.model.add([dummy])
+
+        def test_get_primal(self):
+            self.assertEqual(self.var.primal, None)
+            with open(TESTMODELPATH) as tp:
+                model = Model.from_lp(tp.read())
+            model.configuration.tolerances.optimality = 1e-6
+            print(model.problem.settings)
+            model.optimize()
+            self.assertEqual(model.status, 'optimal')
+            assert_allclose(model.objective.value, 0.8739215069684305, 1e-4, 1e-4)
+            ref_sol = [0.8739215069684306, -16.023526143167608, 16.023526143167604]
+            primals = [var.primal for var in model.variables[0:3]]
+            assert_allclose(primals, ref_sol, 1e-4, 1e-4)
+
+        def test_get_dual(self):
+            with open(TESTMODELPATH) as tp:
+                model = Model.from_lp(tp.read())
+            model.optimize()
+            self.assertEqual(model.status, 'optimal')
+            assert_allclose(model.objective.value, 0.8739215069684305, 1e-4, 1e-4)
+            self.assertTrue(isinstance(model.variables[0].dual, float))
+
+        def test_changing_variable_names_is_reflected_in_the_solver(self):
+            with open(TESTMODELPATH) as tp:
+                model = Model.from_lp(tp.read())
+            for i, variable in enumerate(model.variables):
+                old_name = variable.name
+                variable.name = "var" + str(i)
+                self.assertEqual(variable.name, "var" + str(i))
+                self.assertIn("var" + str(i), model.problem.variables)
+                self.assertIn("var" + str(i), model._variables_to_constraints_mapping)
+                self.assertNotIn(old_name, model.problem.variables)
+                self.assertNotIn(old_name, model.problem.variable_lbs)
+                self.assertNotIn(old_name, model.problem.variable_ubs)
+                self.assertNotIn(old_name, model._variables_to_constraints_mapping)
+
+        def test_osqp_setting_bounds(self):
+            with open(TESTMODELPATH) as tp:
+                model = Model.from_lp(tp.read())
+            var = model.variables[0]
+            var.lb = 1
+            self.assertEqual(var.lb, 1)
+            model.update()
+            self.assertEqual(model.problem.variable_lbs[var.name], 1)
+            var.ub = 2
+            self.assertEqual(var.ub, 2)
+            model.update()
+            self.assertEqual(model.problem.variable_ubs[var.name], 2)
+
+        @unittest.skip("seems to be a problem with OSQP")
+        def test_set_bounds_to_none(self):
+            model = self.model
+            var = self.var
+
+            model.objective = self.interface.Objective(1.0 * var)
+            model.update()
+            print(model.problem.variables)
+            self.assertEqual(model.optimize(), interface.INFEASIBLE)
+            var.ub = 10
+            self.assertEqual(model.optimize(), interface.OPTIMAL)
+            var.ub = None
+            self.assertEqual(model.optimize(), interface.INFEASIBLE)
+            self.model.objective.direction = "min"
+            var.lb = -10
+            self.assertEqual(model.optimize(), interface.OPTIMAL)
+            var.lb = None
+            self.assertEqual(model.optimize(), interface.INFEASIBLE)
+
+        def test_set_bounds_method(self):
+            var = self.interface.Variable("test", lb=-10)
+            c = self.interface.Constraint(var, lb=-100)
+            # OSQP needs at least two variables
+            model = self.interface.Model()
+            obj = self.interface.Objective(1.0 * var)
+            model.add([c])
+            model.objective = obj
+
+            for lb, ub in ((1, 10), (-1, 5), (11, 12)):
+                obj.direction = "max"
+                var.set_bounds(lb, ub)
+                model.optimize()
+                self.assertAlmostEqual(var.primal, ub)
+                obj.direction = "min"
+                model.optimize()
+                self.assertAlmostEqual(var.primal, lb)
+
+            var.set_bounds(None, 0)
+            model.optimize()
+            self.assertAlmostEqual(var.primal, -100)
+
+            obj.direction = "max"
+            var.set_bounds(1, None)
+            self.assertEqual(model.optimize(), interface.INFEASIBLE)
+
+            self.assertRaises(ValueError, var.set_bounds, 2, 1)
+
+        def test_set_wrong_type_raises(self):
+            self.assertRaises(ValueError, self.interface.Variable, name="test", type="mayo")
+            self.assertRaises(Exception, setattr, self.var, 'type', 'ketchup')
+            self.model.add(self.var)
+            self.model.update()
+            self.assertRaises(ValueError, setattr, self.var, "type", "mustard")
+            self.var.type = "continuous"
+            self.assertEqual(self.var.type, "continuous")
+
+        def test_change_variable_type(self):
+            # not supported by OSQP
+            pass
+
+
+
+    class ConstraintTestCase(abstract_test_cases.AbstractConstraintTestCase):
+        interface = osqp_interface
+
+        def test_set_linear_coefficients(self):
+            self.model.add(self.constraint)
+            self.constraint.set_linear_coefficients({Variable('chip'): 33., self.model.variables.R_PGK: -33})
+            coefs = {
+                v.name: self.model.problem.constraint_coefs[(self.constraint.name, v.name)]
+                for v in self.model.variables
+                if (self.constraint.name, v.name) in self.model.problem.constraint_coefs
+            }
+            self.assertEqual(coefs,
+                             dict([('R_PGK', -33.0), ('chap', 1.0), ('chip', 33.0)]))
+
+        def test_get_primal(self):
+            self.assertEqual(self.constraint.primal, None)
+            self.model.optimize()
+            self.assertEqual(self.model.status, 'optimal')
+            assert_allclose(self.model.objective.value, 0.8739215069684305, 1e-3, 1e-3)
+            primals = [constraint.primal for constraint in self.model.constraints]
+            assert_allclose(primals, np.zeros(len(primals)), 1e-3, 1e-3)  # only equality constraints
+
+        def test_get_dual(self):
+            self.assertEqual(self.constraint.primal, None)
+            self.model.optimize()
+            self.assertEqual(self.model.status, 'optimal')
+            assert_allclose(self.model.objective.value, 0.8739215069684305, 1e-3, 1e-3)
+            self.assertRaises(ValueError, getattr, self.constraint, "dual")
+
+        def test_set_constraint_bounds_to_none(self):
+            model = self.interface.Model()
+            var = self.interface.Variable("test")
+            const = self.interface.Constraint(var, lb=-10, ub=10)
+            obj = self.interface.Objective(var)
+            model.add(const)
+            model.objective = obj
+            self.assertEqual(model.optimize(), interface.OPTIMAL)
+            const.ub = None
+            self.assertEqual(model.optimize(), interface.INFEASIBLE)
+            const.ub = 10
+            const.lb = None
+            obj.direction = "min"
+            self.assertEqual(model.optimize(), interface.INFEASIBLE)
+
+
+    class ObjectiveTestCase(abstract_test_cases.AbstractObjectiveTestCase):
+        interface = osqp_interface
+
+        def setUp(self):
+            with open(TESTMODELPATH) as tp:
+                model = Model.from_lp(tp.read())
+            self.obj = model.objective
+            self.model = model
+
+        def test_change_direction(self):
+            self.obj.direction = "min"
+            self.assertEqual(self.obj.direction, "min")
+            self.assertEqual(self.model.problem.direction, 1)
+
+            self.obj.direction = "max"
+            self.assertEqual(self.obj.direction, "max")
+            self.assertEqual(self.model.problem.direction, -1)
+
+
+    class ModelTestCase(abstract_test_cases.AbstractModelTestCase):
+        interface = osqp_interface
+
+        def test_change_variable_type(self):
+            pass
+
+        def test_clone_model_with_lp(self):
+            pass
+
+        def test_pickle_ability(self):
+            self.model.optimize()
+            value = self.model.objective.value
+            pickle_string = pickle.dumps(self.model)
+            from_pickle = pickle.loads(pickle_string)
+            from_pickle.optimize()
+            self.assertAlmostEqual(value, from_pickle.objective.value)
+            self.assertEqual([(var.lb, var.ub, var.name, var.type) for var in from_pickle.variables.values()],
+                             [(var.lb, var.ub, var.name, var.type) for var in self.model.variables.values()])
+            self.assertEqual([(constr.lb, constr.ub, constr.name) for constr in from_pickle.constraints],
+                             [(constr.lb, constr.ub, constr.name) for constr in self.model.constraints])
+
+        @unittest.skip("can't figure this out")
+        def test_config_gets_copied_too(self):
+            self.assertEquals(self.model.configuration.verbosity, 0)
+            self.model.configuration.verbosity = True
+            model_copy = copy.copy(self.model)
+            self.assertTrue(model_copy.configuration.verbosity)
+
+        def test_init_from_existing_problem(self):
+            inner_prob = self.model.problem
+            self.assertEqual(len(self.model.variables), len(inner_prob.variables))
+            self.assertEqual(len(self.model.constraints), len(inner_prob.constraints))
+            self.assertEqual(set(self.model.variables.keys()), inner_prob.variables)
+            self.assertEqual(set(self.model.constraints.keys()), inner_prob.constraints)
+
+        def test_add_non_cplex_conform_variable(self):
+            var = Variable('12x!!@#5_3', lb=-666, ub=666)
+            self.model.add(var)
+            self.assertTrue(var in self.model.variables.values())
+            self.assertIn(var.name, self.model.problem.variables)
+            self.assertEqual(self.model.variables['12x!!@#5_3'].lb, -666)
+            self.assertEqual(self.model.variables['12x!!@#5_3'].ub, 666)
+            repickled = pickle.loads(pickle.dumps(self.model))
+            print(repickled.variables)
+            var_from_pickle = repickled.variables['12x!!@#5_3']
+            self.assertIn(var_from_pickle.name, self.model.problem.variables)
+
+        def test_osqp_remove_variable(self):
+            var = self.model.variables[0]
+            self.assertEqual(var.problem, self.model)
+            self.model.remove(var)
+            self.model.update()
+            self.assertNotIn(var.name, self.model.problem.variables)
+            self.assertNotIn(var.name, self.model.problem.variable_lbs)
+            self.assertNotIn(var.name, self.model.problem.variable_ubs)
+            self.assertEqual(var.problem, None)
+
+        def test_change_of_constraint_is_reflected_in_low_level_solver(self):
+            x = Variable('x', lb=-83.3, ub=1324422.)
+            y = Variable('y', lb=-181133.3, ub=12000.)
+            constraint = Constraint(0.3 * x + 0.4 * y, lb=-100, name='test')
+            self.model.add(constraint)
+            self.assertEqual(
+                (self.model.constraints['test'].expression - (0.4 * y + 0.3 * x)).expand() - 0,
+                0
+            )
+            self.assertEqual(
+                [self.model.problem.constraint_coefs[k]
+                    for k in [('test', 'x'), ('test', 'y')]],
+                [0.3, 0.4])
+            z = Variable('z', lb=3, ub=4, type='integer')
+            constraint += 77. * z
+            self.assertEqual(
+                [self.model.problem.constraint_coefs[k]
+                    for k in [('test', 'x'), ('test', 'y'), ('test', 'z')]],
+                [0.3, 0.4, 77.])
+            self.assertEqual(
+                (self.model.constraints['test'].expression - (0.4 * y + 0.3 * x + 77.0 * z)).expand() - 0,
+                0
+            )
+
+        def test_implicitly_convert_milp_to_lp(self):
+            pass
+
+        def test_integer_batch_duals(self):
+            pass
+
+        def test_integer_constraint_dual(self):
+            pass
+
+        def test_integer_variable_dual(self):
+            pass
+
+        def test_is_integer(self):
+            pass
+
+        def test_objective_handles_constants_2(self):
+            pass
+
+        def test_optimize(self):
+            self.model.optimize()
+            self.assertEqual(self.model.status, 'optimal')
+            assert_allclose(self.model.objective.value, 0.8739215069684303, 1e-3, 1e-3)
+
+        def test_optimize_milp(self):
+            pass
+
+        def test_non_convex_obj(self):
+            pass
+
+        def test_shadow_prices(self):
+            pass
+
+        def test_constraint_set_problem_to_None_caches_the_latest_expression_from_solver_instance(self):
+            x = Variable('x', lb=-83.3, ub=1324422.)
+            y = Variable('y', lb=-181133.3, ub=12000.)
+            constraint = Constraint(0.3 * x + 0.4 * y, lb=-100, name='test')
+            self.model.add(constraint)
+            z = Variable('z', lb=2, ub=5, type='integer')
+            constraint += 77. * z
+            self.model.remove(constraint)
+            self.assertEqual(constraint.name, "test")
+            self.assertEqual(constraint.lb, -100)
+            self.assertEqual(constraint.ub, None)
+            self.assertEqual((constraint.expression - (0.4 * y + 0.3 * x + 77.0 * z)).expand(), 0.0)
+
+        def test_change_of_objective_is_reflected_in_low_level_solver(self):
+            x = Variable('x', lb=-83.3, ub=1324422.)
+            y = Variable('y', lb=-181133.3, ub=12000.)
+            objective = Objective(0.3 * x + 0.4 * y, name='obj', direction='max')
+            self.model.objective = objective
+            for variable in self.model.variables:
+                coeff = self.model.problem.obj_linear_coefs.get(variable.name, 0.0)
+                if variable.name == 'x':
+                    self.assertEqual(coeff, 0.3)
+                elif variable.name == 'y':
+                    self.assertEqual(coeff, 0.4)
+                else:
+                    self.assertEqual(coeff, 0.)
+            z = Variable('z', lb=0.000003, ub=0.000003, type='continuous')
+            objective += 77. * z
+            for variable in self.model.variables:
+                coeff = self.model.problem.obj_linear_coefs.get(variable.name, 0.0)
+                if variable.name == 'x':
+                    self.assertEqual(coeff, 0.3)
+                elif variable.name == 'y':
+                    self.assertEqual(coeff, 0.4)
+                elif variable.name == 'z':
+                    self.assertEqual(coeff, 77.)
+                else:
+                    self.assertEqual(coeff, 0.)
+
+        def test_change_variable_bounds(self):
+            inner_prob = self.model.problem
+            inner_problem_bounds = [
+                (inner_prob.variable_lbs[v.name],
+                 inner_prob.variable_ubs[v.name])
+                for v in self.model.variables
+            ]
+            bounds = [(var.lb, var.ub) for var in self.model.variables.values()]
+            self.assertEqual(bounds, inner_problem_bounds)
+            for var in self.model.variables.values():
+                var.lb = random.uniform(-1000, 1000)
+                var.ub = random.uniform(var.lb, 1000)
+            self.model.update()
+            inner_problem_bounds_new = [
+                (inner_prob.variable_lbs[v.name],
+                 inner_prob.variable_ubs[v.name])
+                for v in self.model.variables
+            ]
+            bounds_new = [(var.lb, var.ub) for var in self.model.variables.values()]
+            self.assertNotEqual(bounds, bounds_new)
+            self.assertNotEqual(inner_problem_bounds, inner_problem_bounds_new)
+            self.assertEqual(bounds_new, inner_problem_bounds_new)
+
+        def test_change_constraint_bounds(self):
+            constraint = self.model.constraints[0]
+            value = 42
+            constraint.ub = value
+            self.assertEqual(constraint.ub, value)
+            constraint.lb = value
+            self.assertEqual(constraint.lb, value)
+            self.assertEqual(self.model.problem.constraint_lbs[constraint.name], value)
+            self.assertEqual(self.model.problem.constraint_ubs[constraint.name], value)
+
+        def test_iadd_objective(self):
+            v1, v2, v3 = list(self.model.variables.values())[0:3]
+            self.model.objective += 2. * v2 - 3. * v3
+            obj_coeff = self.model.problem.obj_linear_coefs
+            self.assertEqual(obj_coeff,
+                             {v1.name: 1, v2.name: 2, v3.name: -3})
+
+        def test_imul_objective(self):
+            self.model.objective *= 2.
+            obj_coeff = self.model.problem.obj_linear_coefs
+            self.assertEqual(obj_coeff, {self.model.variables[0].name: 2.0})
+
+        def test_set_copied_objective(self):
+            obj_copy = copy.copy(self.model.objective)
+            self.model.objective = obj_copy
+            self.assertEqual(self.model.objective.direction, "max")
+            self.assertEqual(self.model.objective.expression, 1.0 * self.model.variables["R_Biomass_Ecoli_core_w_GAM"])
+
+        def test_timeout(self):
+            self.model.configuration.timeout = 1e-6
+            status = self.model.optimize()
+            self.assertEqual(status, 'time_limit')
+
+        def test_set_linear_coefficients_objective(self):
+            self.model.objective.set_linear_coefficients({self.model.variables.R_TPI: 666.})
+            self.assertEqual(self.model.problem.obj_linear_coefs[self.model.variables.R_TPI.name], 666.)
+
+        def test_set_linear_coefficients_constraint(self):
+            constraint = self.model.constraints.M_atp_c
+            coeff_dict = constraint.expression.as_coefficients_dict()
+            self.assertEqual(coeff_dict[self.model.variables.R_Biomass_Ecoli_core_w_GAM], -59.8100000000000)
+            constraint.set_linear_coefficients({self.model.variables.R_Biomass_Ecoli_core_w_GAM: 666.})
+            coeff_dict = constraint.expression.as_coefficients_dict()
+            self.assertEqual(coeff_dict[self.model.variables.R_Biomass_Ecoli_core_w_GAM], 666.)
+
+        def test_osqp_change_objective_can_handle_removed_vars(self):
+            self.model.objective = Objective(self.model.variables[0])
+            self.model.remove(self.model.variables[0])
+            self.model.update()
+            self.model.objective = Objective(self.model.variables[1] ** 2)
+            self.model.remove(self.model.variables[1])
+            self.model.update()
+            self.model.objective = Objective(self.model.variables[2])
+            self.assertEqual(self.model.problem.obj_linear_coefs,
+                {self.model.variables[2].name: 1.0})
+
+
+    class ConfigurationTestCase(abstract_test_cases.AbstractConfigurationTestCase):
+
+        interface = osqp_interface
+
+        def setUp(self):
+            self.model = Model()
+            self.configuration = self.model.configuration
+
+        def test_tolerance_parameters(self):
+            model = self.interface.Model()
+            params = ["optimality", "feasibility"]
+            for param in params:
+                val = getattr(model.configuration.tolerances, param)
+                print(val)
+                setattr(model.configuration.tolerances, param, 2 * val)
+                self.assertEqual(
+                    getattr(model.configuration.tolerances, param), 2 * val
+                )
+
+        def test_lp_method(self):
+            for option in self.interface._LP_METHODS[1:3]:
+                self.configuration.lp_method = option
+                self.assertEqual(self.configuration.lp_method, option)
+                self.assertEqual(self.model.problem.settings["linsys_solver"],
+                    option)
+
+            self.assertRaises(ValueError, setattr, self.configuration, "lp_method", "weird_stuff")
+
+        def test_qp_method(self):
+            for option in osqp_interface._QP_METHODS:
+                self.configuration.qp_method = option
+                self.assertEqual(self.configuration.qp_method, option)
+
+            self.assertRaises(ValueError, setattr, self.configuration, "qp_method", "weird_stuff")
+
+        def test_verbosity(self):
+            for i in range(4):
+                self.model.configuration.verbosity = i
+                self.assertEqual(self.model.configuration.verbosity, i)
+
+        def test_presolve(self):
+            for presolve in (True, False):
+                self.configuration.presolve = presolve
+                self.assertEqual(self.configuration.presolve, presolve)
+
+            self.assertRaises(ValueError, setattr, self.configuration, "presolve", "what?")
+
+
+    class QuadraticProgrammingTestCase(abstract_test_cases.AbstractQuadraticProgrammingTestCase):
+        def setUp(self):
+            self.model = Model()
+            self.x1 = Variable("x1", lb=0)
+            self.x2 = Variable("x2", lb=0)
+            self.c1 = Constraint(self.x1 + self.x2, lb=1)
+            self.model.add([self.x1, self.x2, self.c1])
+
+        def test_convex_obj(self):
+            model = self.model
+            obj = Objective(self.x1 ** 2 + self.x2 ** 2, direction="min")
+            model.objective = obj
+            model.optimize()
+            assert_allclose(model.objective.value, 0.5, 1e-4, 1e-4)
+            assert_allclose(self.x1.primal, 0.5, 1e-4, 1e-4)
+            assert_allclose(self.x2.primal, 0.5, 1e-4, 1e-4)
+
+            obj_2 = Objective(self.x1, direction="min")
+            model.objective = obj_2
+            model.optimize()
+            assert_allclose(model.objective.value, 0.0, 1e-4, 1e-4)
+            assert_allclose(self.x1.primal, 0.0, 1e-4, 1e-4)
+
+        def test_non_convex_obj(self):
+            model = self.model
+            obj = Objective(self.x1 * self.x2, direction="min")
+            model.objective = obj
+            self.assertRaises(ValueError, model.optimize)
+
+            obj_2 = Objective(self.x1, direction="min")
+            model.objective = obj_2
+            model.optimize()
+            assert_allclose(model.objective.value, 0.0, 1e-4, 1e-4)
+            assert_allclose(self.x1.primal, 0.0, 1e-4, 1e-4)
+
+        def test_qp_convex(self):
+            for qp, info in six.iteritems(LARGE_QPS):
+                nv, nc, ref_sol = info
+                prob = json.load(open(qp))
+                model = Model.from_json(prob)
+                model.optimize()
+                self.assertEqual(len(model.variables), nv)
+                self.assertEqual(len(model.constraints), nc)
+                self.assertEqual(model.status, OPTIMAL)
+                assert_allclose(model.objective.value, ref_sol, 1e-3, 1e-3)
+
+        def test_qp_non_convex(self):
+            pass
+
+        def test_quadratic_objective_expression(self):
+            objective = Objective(self.x1 ** 2 + self.x2 ** 2, direction="min")
+            self.model.objective = objective
+            self.assertEqual((self.model.objective.expression - (self.x1 ** 2 + self.x2 ** 2)).simplify(), 0)
+            self.assertEqual(len(self.model.problem.obj_quadratic_coefs), 2)
+
+
+    class UnsolvedTestCase(unittest.TestCase):
+
+        interface = osqp_interface
+
+        def setUp(self):
+            model = self.interface.Model()
+            x = self.interface.Variable('x', lb=0, ub=10)
+            constr1 = self.interface.Constraint(1. * x, lb=3, name="constr1")
+            obj = self.interface.Objective(2 * x)
+            model.add(x)
+            model.add(constr1)
+            model.objective = obj
+            self.model = model
+            self.continuous_var = x
+            self.constraint = constr1
+
+        def test_status(self):
+            self.assertIs(self.model.status, None)
+
+        def test_objective_value(self):
+            self.assertIs(self.model.objective.value, None)
+
+        def test_variable_primal(self):
+            self.assertIs(self.continuous_var.primal, None)
+
+        def test_variable_dual(self):
+            self.assertIs(self.continuous_var.dual, None)
+
+        def test_constraint_primal(self):
+            self.assertIs(self.constraint.primal, None)
+
+        def test_constraint_dual(self):
+            with self.assertRaises(ValueError) as context:
+                self.constraint.dual
+            self.assertIn("Not supported", str(context.exception))
+
+        def test_primal_values(self):
+            with self.assertRaises(SolverError) as context:
+                self.model.primal_values
+            self.assertIn("not been solved", str(context.exception))
+
+        def test_constraint_values(self):
+            with self.assertRaises(SolverError) as context:
+                self.model.constraint_values
+            self.assertIn("not been solved", str(context.exception))
+
+        def test_reduced_costs(self):
+            with self.assertRaises(SolverError) as context:
+                self.model.reduced_costs
+            self.assertIn("not been solved", str(context.exception))
+
+        def test_shadow_prices(self):
+            with self.assertRaises(SolverError) as context:
+                self.model.shadow_prices
+            self.assertIn("not been solved", str(context.exception))
+
+
+if __name__ == '__main__':
+    nose.runmodule()

--- a/src/optlang/tests/test_osqp_interface.py
+++ b/src/optlang/tests/test_osqp_interface.py
@@ -70,7 +70,12 @@ else:
             assert_allclose(primals, ref_sol, 1e-4, 1e-4)
 
         def test_get_dual(self):
-            pass
+            with open(TESTMODELPATH) as tp:
+                model = Model.from_lp(tp.read())
+            model.optimize()
+            self.assertEqual(model.status, 'optimal')
+            assert_allclose(model.objective.value, 0.8739215069684305, 1e-4, 1e-4)
+            self.assertTrue(isinstance(model.variables[0].dual, float))
 
         def test_changing_variable_names_is_reflected_in_the_solver(self):
             with open(TESTMODELPATH) as tp:
@@ -320,9 +325,6 @@ else:
         def test_is_integer(self):
             pass
 
-        def test_objective_handles_constants_2(self):
-            pass
-
         def test_optimize(self):
             self.model.optimize()
             self.assertEqual(self.model.status, 'optimal')
@@ -332,9 +334,6 @@ else:
             pass
 
         def test_non_convex_obj(self):
-            pass
-
-        def test_reduced_costs(self):
             pass
 
         def test_constraint_set_problem_to_None_caches_the_latest_expression_from_solver_instance(self):
@@ -559,6 +558,7 @@ else:
                 assert_allclose(model.objective.value, ref_sol, 1e-3, 1e-3)
 
         def test_qp_non_convex(self):
+            # unsupported by OSQP
             pass
 
         def test_quadratic_objective_expression(self):
@@ -594,7 +594,7 @@ else:
             self.assertIs(self.continuous_var.primal, None)
 
         def test_variable_dual(self):
-            pass
+            self.assertIs(self.continuous_var.primal, None)
 
         def test_constraint_primal(self):
             self.assertIs(self.constraint.primal, None)
@@ -613,7 +613,9 @@ else:
             self.assertIn("not been solved", str(context.exception))
 
         def test_reduced_costs(self):
-            pass
+            with self.assertRaises(SolverError) as context:
+                self.model.reduced_costs
+            self.assertIn("not been solved", str(context.exception))
 
         def test_shadow_prices(self):
             with self.assertRaises(SolverError) as context:

--- a/src/optlang/tests/test_osqp_interface.py
+++ b/src/optlang/tests/test_osqp_interface.py
@@ -250,12 +250,11 @@ else:
             self.assertEqual([(constr.lb, constr.ub, constr.name) for constr in from_pickle.constraints],
                              [(constr.lb, constr.ub, constr.name) for constr in self.model.constraints])
 
-        @unittest.skip("can't figure this out")
         def test_config_gets_copied_too(self):
             self.assertEquals(self.model.configuration.verbosity, 0)
-            self.model.configuration.verbosity = True
+            self.model.configuration.verbosity = 1
             model_copy = copy.copy(self.model)
-            self.assertTrue(model_copy.configuration.verbosity)
+            self.assertEqual(model_copy.configuration.verbosity, 1)
 
         def test_init_from_existing_problem(self):
             inner_prob = self.model.problem
@@ -480,19 +479,25 @@ else:
                     getattr(model.configuration.tolerances, param), 2 * val
                 )
 
+        def test_solver(self):
+            for option in ("qdldl", "mkl pardiso"):
+                self.configuration.linear_solver = option
+                self.assertEqual(self.configuration.linear_solver, option)
+                self.assertEqual(self.model.problem.settings["linsys_solver"], option)
+
+            self.assertRaises(ValueError, setattr, self.configuration, "lp_method", "weird_stuff")
+
         def test_lp_method(self):
-            for option in self.interface._LP_METHODS[1:3]:
+            for option in ("auto", "primal"):
                 self.configuration.lp_method = option
-                self.assertEqual(self.configuration.lp_method, option)
-                self.assertEqual(self.model.problem.settings["linsys_solver"],
-                    option)
+                self.assertEqual(self.configuration.lp_method, "primal")
 
             self.assertRaises(ValueError, setattr, self.configuration, "lp_method", "weird_stuff")
 
         def test_qp_method(self):
             for option in osqp_interface._QP_METHODS:
                 self.configuration.qp_method = option
-                self.assertEqual(self.configuration.qp_method, option)
+                self.assertEqual(self.configuration.qp_method, "primal")
 
             self.assertRaises(ValueError, setattr, self.configuration, "qp_method", "weird_stuff")
 

--- a/src/optlang/util.py
+++ b/src/optlang/util.py
@@ -105,7 +105,8 @@ def list_available_solvers():
     dict
         A dict like {'GLPK': True, 'GUROBI': False, ...}
     """
-    solvers = dict(GUROBI=False, GLPK=False, MOSEK=False, CPLEX=False, SCIPY=False)
+    solvers = dict(GUROBI=False, GLPK=False, MOSEK=False, CPLEX=False,
+                   SCIPY=False, OSQP=False)
     try:
         import gurobipy
 

--- a/src/optlang/util.py
+++ b/src/optlang/util.py
@@ -233,7 +233,7 @@ def parse_expr(expr, local_dict=None):
     elif expr["type"] == "Mul":
         return mul([parse_expr(arg, local_dict) for arg in expr["args"]])
     elif expr["type"] == "Pow":
-        return Pow(parse_expr(arg, local_dict) for arg in expr["args"])
+        return Pow(*[parse_expr(arg, local_dict) for arg in expr["args"]])
     elif expr["type"] == "Symbol":
         try:
             return local_dict[expr["name"]]

--- a/src/optlang/util.py
+++ b/src/optlang/util.py
@@ -135,6 +135,13 @@ def list_available_solvers():
     except Exception:
         log.debug('CPLEX python bindings not available.')
     try:
+        import osqp
+
+        solvers['OSQP'] = True
+        log.debug('OSQP python bindings found at %s' % os.path.dirname(osqp.__file__))
+    except Exception:
+        log.debug('OSQP python bindings not available.')
+    try:
         from scipy import optimize
         optimize.linprog
 

--- a/src/optlang/util.py
+++ b/src/optlang/util.py
@@ -135,13 +135,24 @@ def list_available_solvers():
         log.debug('CPLEX python bindings found at %s' % os.path.dirname(cplex.__file__))
     except Exception:
         log.debug('CPLEX python bindings not available.')
+
+    # OSQP can be provided by the base or CUDA package
+    solvers['OSQP'] = False
+    try:
+        import cuosqp
+        solvers['OSQP'] = True
+        log.debug('OSQP python bindings found at %s' % os.path.dirname(cuosqp.__file__))
+    except Exception:
+        pass
     try:
         import osqp
-
         solvers['OSQP'] = True
         log.debug('OSQP python bindings found at %s' % os.path.dirname(osqp.__file__))
     except Exception:
+        pass
+    if not solvers['OSQP']:
         log.debug('OSQP python bindings not available.')
+
     try:
         from scipy import optimize
         optimize.linprog

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ deps =
      nose-progressive
      rednose
      scipy
-     osqp
+     osqp < 0.6.2
      symengine: symengine
 passenv = CI
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,7 @@ deps =
      nose-progressive
      rednose
      scipy
+     osqp
      symengine: symengine
 passenv = CI
 commands =


### PR DESCRIPTION
This is a first working version of a QP solver via [OSQP](https://osqp.org). OSQP expects the problem to be sparse and static so I added a thin compatibility layer that manages the OSQP problem via dictionaries. All operations on that layer are at worst O(nv + nc) but it makes problem setup about 10-20% of the entire solve time for most models. Could maybe be optimized more in the future but should be sufficient for now. Still need to add tests but I added some more complicated models to the test data for now.

It now supports all features such as reduced costs etc. This version is also faster than the previous PR since it gets primals and duals via the C interface instead of evaluating expressions. We used it in the recent MICOM course and it worked well.

Demo:

```bash
Python 3.9.1 (default, Dec  8 2020, 07:51:42) 
Type 'copyright', 'credits' or 'license' for more information
IPython 7.19.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from optlang import osqp_interface as o

In [2]: import json

In [3]: qp = json.load(open("src/optlang/tests/data/QPLIB_8785.json"))

In [4]: mod = o.Model.from_json(qp)

In [6]: len(mod.variables), len(mod.constraints)
Out[6]: (10399, 11362)

In [7]: mod.configuration.verbosity = 1

In [8]: mod.configuration.tolerances.optimality = 1e-6

In [9]: mod.optimize()
-----------------------------------------------------------------
           OSQP v0.6.0  -  Operator Splitting QP Solver
              (c) Bartolomeo Stellato,  Goran Banjac
        University of Oxford  -  Stanford University 2019
-----------------------------------------------------------------
problem:  variables n = 10399, constraints m = 21761
          nnz(P) + nnz(A) = 73422
settings: linear system solver = qdldl,
          eps_abs = 1.0e-06, eps_rel = 1.0e-06,
          eps_prim_inf = 1.0e-06, eps_dual_inf = 1.0e-06,
          rho = 1.00e+00 (adaptive),
          sigma = 1.00e-06, alpha = 1.60, max_iter = 100000
          check_termination: on (interval 25),
          scaling: off, scaled_termination: off
          warm start: on, polish: on, time_limit: off

iter   objective    pri res    dua res    rho        time
   1   0.0000e+00   9.90e+01   9.90e+01   1.00e+00   5.97e-01s
 200   7.8676e+03   3.39e-02   2.37e-05   9.64e-04   3.62e+00s
 300   7.8675e+03   1.17e-04   2.22e-07   6.19e-03   4.87e+00s
plsh   7.8675e+03   8.53e-14   6.68e-10   --------   5.60e+00s

status:               solved
solution polish:      successful
number of iterations: 300
optimal objective:    7867.4911
run time:             5.60e+00s
optimal rho estimate: 5.22e-03

Out[9]: 'optimal'

In [10]: mod.objective.value  # reference solution: 7867.4911490000004051
Out[10]: 7867.491148760153
```

One should note that this is a direct solver so it performs pretty bad for LPs or at very low tolerances. I added some optimizations for LP so it works ok-ish but worse than GLPK. However it is great for QPs so I think having a specialized solver for that is still helpful. 

# TODO

- [x] add tests
- [ ] add documentation
- [x] update deps? 