### PR TITLE
Fixes for the gurobi interface and OSQP tolerances

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,12 @@
 Next Release
 ------------
 
+1.5.2
+-----
+* Gurobi can now serialize its configuration correctly. This also fixes pickling of Gurobi models.
+* Fix the shim for integrality tolerance in OSQP which makes it easier to clone OSQP Models to other solvers.
+* Fix an issue where one could not rename variables in Gurobi version 9.
+
 1.5.1
 -----
 * GLPK now respects `Configuration.tolerances.integrality` again

--- a/src/optlang/gurobi_interface.py
+++ b/src/optlang/gurobi_interface.py
@@ -90,13 +90,12 @@ def _constraint_lb_and_ub_to_gurobi_sense_rhs_and_range_value(lb, ub):
 class Variable(interface.Variable):
     def __init__(self, name, *args, **kwargs):
         super(Variable, self).__init__(name, **kwargs)
-        self._original_name = name  # due to bug with getVarByName ... TODO: file bug report on gurobi google group
 
     @property
     def _internal_variable(self):
         if getattr(self, 'problem', None) is not None:
 
-            internal_variable = self.problem.problem.getVarByName(self._original_name)
+            internal_variable = self.problem.problem.getVarByName(self.name)
 
             assert internal_variable is not None
             # if internal_variable is None:

--- a/src/optlang/gurobi_interface.py
+++ b/src/optlang/gurobi_interface.py
@@ -616,11 +616,6 @@ class Model(interface.Model):
     def __setstate__(self, repr_dict):
         with TemporaryFilename(suffix=".lp", content=repr_dict["lp"]) as tmp_file_name:
             problem = gurobipy.read(tmp_file_name)
-        # turn off logging completely, get's configured later
-        problem.set_error_stream(None)
-        problem.set_warning_stream(None)
-        problem.set_log_stream(None)
-        problem.set_results_stream(None)
         self.__init__(problem=problem)
         self.configuration = Configuration()
         self.configuration.problem = self

--- a/src/optlang/gurobi_interface.py
+++ b/src/optlang/gurobi_interface.py
@@ -60,6 +60,8 @@ _VTYPE_TO_GUROBI_VTYPE = {'continuous': gurobipy.GRB.CONTINUOUS, 'integer': guro
                           'binary': gurobipy.GRB.BINARY}
 _GUROBI_VTYPE_TO_VTYPE = dict((val, key) for key, val in _VTYPE_TO_GUROBI_VTYPE.items())
 
+_GUROBI_MAJOR = int(gurobipy.__versio__.split(".")[0])
+
 
 def _constraint_lb_and_ub_to_gurobi_sense_rhs_and_range_value(lb, ub):
     """Helper function used by Constraint and Model"""
@@ -90,16 +92,15 @@ def _constraint_lb_and_ub_to_gurobi_sense_rhs_and_range_value(lb, ub):
 class Variable(interface.Variable):
     def __init__(self, name, *args, **kwargs):
         super(Variable, self).__init__(name, **kwargs)
+        self._original_name = name
 
     @property
     def _internal_variable(self):
         if getattr(self, 'problem', None) is not None:
-
-            internal_variable = self.problem.problem.getVarByName(self.name)
-
-            assert internal_variable is not None
-            # if internal_variable is None:
-            #     raise Exception('Cannot find variable {}')
+            if _GUROBI_MAJOR < 9:
+                internal_variable = self.problem.problem.getVarByName(self._original_name)
+            else:
+                internal_variable = self.problem.problem.getVarByName(self.name)
             return internal_variable
         else:
             return None

--- a/src/optlang/gurobi_interface.py
+++ b/src/optlang/gurobi_interface.py
@@ -60,7 +60,8 @@ _VTYPE_TO_GUROBI_VTYPE = {'continuous': gurobipy.GRB.CONTINUOUS, 'integer': guro
                           'binary': gurobipy.GRB.BINARY}
 _GUROBI_VTYPE_TO_VTYPE = dict((val, key) for key, val in _VTYPE_TO_GUROBI_VTYPE.items())
 
-_GUROBI_MAJOR = int(gurobipy.__versio__.split(".")[0])
+# hacky way since Gurobi does not allow getting the version via the API
+_IS_GUROBI_9_OR_NEWER = hasattr(gurobipy, "MLinExpr")
 
 
 def _constraint_lb_and_ub_to_gurobi_sense_rhs_and_range_value(lb, ub):
@@ -97,10 +98,10 @@ class Variable(interface.Variable):
     @property
     def _internal_variable(self):
         if getattr(self, 'problem', None) is not None:
-            if _GUROBI_MAJOR < 9:
-                internal_variable = self.problem.problem.getVarByName(self._original_name)
-            else:
+            if _IS_GUROBI_9_OR_NEWER:
                 internal_variable = self.problem.problem.getVarByName(self.name)
+            else:
+                internal_variable = self.problem.problem.getVarByName(self._original_name)
             return internal_variable
         else:
             return None

--- a/src/optlang/osqp_interface.py
+++ b/src/optlang/osqp_interface.py
@@ -652,7 +652,7 @@ class Configuration(interface.MathematicalProgrammingConfiguration):
         self.problem.problem.settings["eps_dual_inf"] = value
 
     def _get_integrality(self):
-        return None
+        return 1e-6
 
     def _set_integrality(self, value):
         pass

--- a/src/optlang/symbolics.py
+++ b/src/optlang/symbolics.py
@@ -36,8 +36,7 @@ if SYMENGINE_PREFERENCE.lower() in ("false", "no", "off"):
 else:  # pragma: no cover
     try:
         import symengine
-        import symengine.sympy_compat
-        from symengine.sympy_compat import Symbol as symengine_Symbol
+        from symengine import Symbol as symengine_Symbol
     except ImportError as e:
         if SYMENGINE_PREFERENCE.lower() in ("true", "yes", "on"):
             logger.warn("Symengine could not be imported: " + str(e))
@@ -59,11 +58,11 @@ if USE_SYMENGINE:  # pragma: no cover # noqa: C901
     Zero = Real(0)
     One = Real(1)
     NegativeOne = Real(-1)
-    sympify = symengine.sympy_compat.sympify
+    sympify = symengine.sympify
 
     Add = symengine.Add
     Mul = symengine.Mul
-    Pow = symengine.sympy_compat.Pow
+    Pow = symengine.Pow
 
     class Symbol(symengine_Symbol):
         def __new__(cls, name, *args, **kwargs):

--- a/src/optlang/tests/test_gurobi_interface.py
+++ b/src/optlang/tests/test_gurobi_interface.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2016 Novo Nordisk Foundation Center for Biosustainability, DTU.
 # See LICENSE for details.
 
+import pickle
 import unittest
 
 try:  # noqa: C901
@@ -178,6 +179,15 @@ else:
 
             self.assertEqual(self.model.constraints.keys(),
                              [constr.ConstrName for constr in self.model.problem.getConstrs()])
+
+        def test_model_can_be_pickled(self):
+            s = pickle.dumps(self.model)
+            mod = pickle.loads(s)
+            self.assertEqual(len(self.model.variables), len(mod.variables))
+            self.assertEqual(len(self.model.constraints), len(mod.constraints))
+            self.assertEqual(self.model.configuration.presolve, mod.configuration.presolve)
+            self.assertEqual(self.model.configuration.tolerances.feasibility,
+                             mod.configuration.tolerances.feasibility)
 
         def test_gurobi_add_variable(self):
             var = Variable('x')

--- a/src/optlang/tests/test_osqp_interface.py
+++ b/src/optlang/tests/test_osqp_interface.py
@@ -252,7 +252,7 @@ else:
                              [(constr.lb, constr.ub, constr.name) for constr in self.model.constraints])
 
         def test_config_gets_copied_too(self):
-            self.assertEquals(self.model.configuration.verbosity, 0)
+            self.assertEqual(self.model.configuration.verbosity, 0)
             self.model.configuration.verbosity = 1
             model_copy = copy.copy(self.model)
             self.assertEqual(model_copy.configuration.verbosity, 1)

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = isort, black, flake8, safety, docs, py27, py3{6,7,8,9}-symengine
 
 [gh-actions]
 python =
-     2.7: safety, py27
+     2.7: py27
      3.6: safety, py36, py36-symengine
      3.7: safety, py37, py37-symengine
      3.8: safety, py38, py38-symengine

--- a/tox.ini
+++ b/tox.ini
@@ -75,6 +75,7 @@ commands=
 
 [testenv:safety]
 deps=
+     pip>=21.1
      safety
 commands=
      safety check --full-report


### PR DESCRIPTION
* [X] fix #232
* [X] description of feature/fix
* [X] tests added/passed
* [X] add an entry to the [next release](../CHANGELOG.rst)

This PR fixes several issues with Gurobi and a bug where one could not clone from the OSQP interface. 

## Fixes

- renaming variables was broken due to an obsolete workaround (fixed in Gurobi 9.1), now works
- now correctly serializes the configuration in the Gurobi interface (fixes pickling)
- added a pickling test for gurobi
- fixes 2 broken tests for Gurobi
- fixed the shim for the integrality tolerance in osqp_interface so it can be cloned to other interfaces

## Tests on all interfaces

<details>

```
============================================================================ test session starts =============================================================================
platform linux -- Python 3.7.10, pytest-6.2.3, py-1.10.0, pluggy-0.13.1
rootdir: /users/cdiener/optlang, configfile: tox.ini, testpaths: src/optlang/tests
plugins: anyio-2.2.0
collected 858 items                                                                                                                                                          

src/optlang/tests/test_change_solver.py .....                                                                                                                          [  0%]
src/optlang/tests/test_coinor_cbc_interface.py s.s...s........s.....s......................s.........................sss..........................s...                 [ 12%]
src/optlang/tests/test_container.py .......................                                                                                                            [ 15%]
src/optlang/tests/test_cplex_interface.py .......s...................................s...................s.............................................ss............. [ 29%]
.....                                                                                                                                                                  [ 30%]
src/optlang/tests/test_duality.py ................                                                                                                                     [ 32%]
src/optlang/tests/test_elements.py .................                                                                                                                   [ 34%]
src/optlang/tests/test_expression_parsing.py ...                                                                                                                       [ 34%]
src/optlang/tests/test_glpk_exact_interface.py ......s..............s....................s....................s....ssss.......s...............                         [ 45%]
src/optlang/tests/test_glpk_interface.py .......s..............................................................................................                        [ 57%]
src/optlang/tests/test_gurobi_interface.py .........s............................................................s.s................................s.s.               [ 70%]
src/optlang/tests/test_inspyred_interface.py s                                                                                                                         [ 70%]
src/optlang/tests/test_interface.py .............................                                                                                                      [ 73%]
src/optlang/tests/test_io.py ...                                                                                                                                       [ 74%]
src/optlang/tests/test_netlib_glpk_exact_interface.py x                                                                                                                [ 74%]
src/optlang/tests/test_netlib_glpk_interface.py x                                                                                                                      [ 74%]
src/optlang/tests/test_osqp_interface.py .......s.................................................................................................................     [ 88%]
src/optlang/tests/test_scipy_interface.py ..ss..s............s.s.................s..ss...sss..s.s..s..s.ssss.ssssss......sss........sss..s                             [ 99%]
src/optlang/tests/test_symbolics.py ..                                                                                                                                 [ 99%]
src/optlang/tests/test_util.py ..                                                                                                                                      [100%]

============================================================================== warnings summary ==============================================================================
../miniconda3/envs/micom-devel/lib/python3.7/site-packages/nose/importer.py:12
  /users/cdiener/miniconda3/envs/micom-devel/lib/python3.7/site-packages/nose/importer.py:12: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
    from imp import find_module, load_module, acquire_lock, release_lock

src/optlang/tests/test_netlib_glpk_exact_interface.py:19
  src/optlang/tests/test_netlib_glpk_exact_interface.py:19: PytestCollectionWarning: yield tests were removed in pytest 4.0 - test_netlib will be ignored
    def test_netlib(netlib_tar_path=os.path.join(os.path.dirname(__file__), 'data/netlib_lp_problems.tar.gz')):

src/optlang/tests/test_netlib_glpk_interface.py:19
  src/optlang/tests/test_netlib_glpk_interface.py:19: PytestCollectionWarning: yield tests were removed in pytest 4.0 - test_netlib will be ignored
    def test_netlib(netlib_tar_path=os.path.join(os.path.dirname(__file__), 'data/netlib_lp_problems.tar.gz')):

src/optlang/tests/test_coinor_cbc_interface.py::ModelTestCase::test_clone_model_with_lp
src/optlang/tests/test_coinor_cbc_interface.py::ModelTestCase::test_clone_small_model_with_lp
src/optlang/tests/test_cplex_interface.py::ModelTestCase::test_clone_model_with_lp
src/optlang/tests/test_glpk_exact_interface.py::ModelTestCase::test_clone_model_with_lp
src/optlang/tests/test_glpk_interface.py::ModelTestCase::test_clone_model_with_lp
src/optlang/tests/test_gurobi_interface.py::ModelTestCase::test_clone_model_with_lp
  /users/cdiener/optlang/src/optlang/interface.py:1135: UserWarning: Cloning with LP formats can change variable and constraint ID's.
    warnings.warn("Cloning with LP formats can change variable and constraint ID's.")

src/optlang/tests/test_gurobi_interface.py: 5643 warnings
  /users/cdiener/optlang/src/optlang/interface.py:1474: DeprecationWarning: Deprecated, pass a TempConstr or use Model.addLConstr
    self._add_constraints(add_constr)

src/optlang/tests/test_gurobi_interface.py::ConstraintTestCase::test_setting_bounds
  /users/cdiener/optlang/src/optlang/gurobi_interface.py:316: DeprecationWarning: Deprecated, pass a TempConstr or use Model.addLConstr
    self._set_constraint_bounds(sense, rhs, range_value)

src/optlang/tests/test_gurobi_interface.py::ModelTestCase::test_add_constraints
  /users/cdiener/optlang/src/optlang/interface.py:1479: DeprecationWarning: Deprecated, pass a TempConstr or use Model.addLConstr
    self._add_constraints(add_constr_sloppy, sloppy=True)

src/optlang/tests/test_gurobi_interface.py: 73 warnings
  /users/cdiener/optlang/src/optlang/interface.py:1566: DeprecationWarning: Deprecated, pass a TempConstr or use Model.addLConstr
    self._add_constraints([constraint], sloppy=sloppy)

src/optlang/tests/test_osqp_interface.py: 64 warnings
  /users/cdiener/miniconda3/envs/micom-devel/lib/python3.7/site-packages/osqp/utils.py:74: DeprecationWarning: `np.int` is a deprecated alias for the builtin `int`. To silence this warning, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    np.zeros((0,), dtype=np.int),

src/optlang/tests/test_osqp_interface.py: 64 warnings
  /users/cdiener/miniconda3/envs/micom-devel/lib/python3.7/site-packages/osqp/utils.py:75: DeprecationWarning: `np.int` is a deprecated alias for the builtin `int`. To silence this warning, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    np.zeros((n+1,), dtype=np.int)),

-- Docs: https://docs.pytest.org/en/stable/warnings.html
==================================================== 792 passed, 64 skipped, 2 xfailed, 5855 warnings in 72.68s (0:01:12) ====================================================

```

</details>