### PR TITLE
move GLPK scaling to the right place

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,8 @@
 
 Next Release
 ------------
+* fixes problem scaling for GLPK
+* fixes scaling output in GLPK that could not be turned off
 
 1.5.2
 -----

--- a/src/optlang/glpk_interface.py
+++ b/src/optlang/glpk_interface.py
@@ -494,7 +494,6 @@ class Model(interface.Model):
     def _initialize_problem(self):
         self.problem = glp_create_prob()
         glp_create_index(self.problem)
-        glp_scale_prob(self.problem, GLP_SF_AUTO)
         if self.name is not None:
             _glpk_validate_id(self.name)
             glp_set_prob_name(self.problem, str(self.name))
@@ -580,7 +579,6 @@ class Model(interface.Model):
             ),
             problem=self,
             direction={GLP_MIN: 'min', GLP_MAX: 'max'}[glp_get_obj_dir(self.problem)])
-        glp_scale_prob(self.problem, GLP_SF_AUTO)
 
     @classmethod
     def from_lp(cls, lp_form):
@@ -705,6 +703,7 @@ class Model(interface.Model):
         return status
 
     def _optimize(self):
+        glp_scale_prob(self.problem, GLP_SF_AUTO)
         status = self._run_glp_simplex()
 
         # Sometimes GLPK gets itself stuck with an invalid basis. This will help it get rid of it.
@@ -721,7 +720,6 @@ class Model(interface.Model):
             status = self._run_glp_mip()
             if status == 'undefined' or status == 'infeasible':
                 # Let's see if the presolver and some scaling can fix this issue
-                glp_scale_prob(self.problem, GLP_SF_AUTO)
                 original_presolve_setting = self.configuration.presolve
                 self.configuration.presolve = True
                 status = self._run_glp_mip()


### PR DESCRIPTION
* [X] fix #238
* [X] description of feature/fix
* [X] tests added/passed
* [X] add an entry to the [next release](../CHANGELOG.rst)

While looking at fixing the GLPK scaling output I noticed that problem scaling actually did not take in the right place. The problem has to be scaled after it is fully built, however scaling was often performed before adding variables and constraints which has no effect. The best place to scale is before optimization as it ensures that the model is built and all changes are applied.

As a side effect that now also respects the verbosity output for scaling.

Example:

```
Python 3.10.5 (main, Jun  8 2022, 09:26:22) [GCC 11.3.0]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.4.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from cobra.io import load_model

In [2]: mod = load_model("textbook")

In [3]: mod.solver = "glpk"

In [4]: # note that there was no output here as before

In [5]: mod.solver.configuration.verbosity = 3

In [6]: mod.optimize()
Scaling...
 A: min|aij| =  7.090e-02  max|aij| =  5.981e+01  ratio =  8.436e+02
GM: min|aij| =  1.856e-01  max|aij| =  5.389e+00  ratio =  2.904e+01
EQ: min|aij| =  3.443e-02  max|aij| =  1.000e+00  ratio =  2.904e+01
GLPK Simplex Optimizer 5.0
72 rows, 190 columns, 720 non-zeros
      0: obj =  -0.000000000e+00 inf =   1.006e+00 (5)
     54: obj =  -0.000000000e+00 inf =   1.274e-15 (0)
*    81: obj =   8.739215070e-01 inf =   2.428e-14 (0)
OPTIMAL LP SOLUTION FOUND
Out[6]: <Solution 0.874 at 0x7f3bfcb9c070>

In [7]: # note that there was actual scaling here, this did not happen before
```