### PR TITLE
pin working numpy in CI

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,7 @@
 
 Next Release
 ------------
+* remove deprecated numpy type casts
 
 1.6.1
 -----

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,7 @@ deps =
      pytest
      pytest-cov
      scipy
+     numpy >=1.13,<1.24
      osqp >= 0.6.2
      mip >= 1.9.1
      cplex


### PR DESCRIPTION
* [X] description of feature/fix
* [X] tests added/passed

This pins a numpy version in the CI that will work with OSQP.
