### PR TITLE
several fixes to support upstream changes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: []"3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: []"3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v2

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,7 @@ Next Release
 * When sympy is used the internal Symbol class now derives from sympy.core.Dummy. This
   circumvents the hack in place to make Symbols unique and makes optlang work with
   sympy>=1.12 again.
-* Updated the scipy and the tests to work with newer versions of those packages.
+* Updated the scipy and the jsonschema tests to work with newer versions of those packages.
 * Package version dependencies are now more specific.
 * Tests are run for sympy and symengine now.
 * Updated support Python versions to >=3.8.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,10 +1,20 @@
 =======
 
 Next Release
-------------
-* remove deprecated numpy type casts
+-----
 
+1.7.0
+-----
+* remove deprecated numpy type casts
 * The symbolics module now has consistent exports
+* When sympy is used the internal Symbol class now derives from sympy.core.Dummy. This
+  circumvents the hack in place to make Symbols unique and makes optlang work with
+  sympy>=1.12 again.
+* Updated the scipy and the tests to work with newer versions of those packages.
+* Package version dependencies are now more specific.
+* Tests are run for sympy and symengine now.
+* Updated support Python versions to >=3.8.
+
 
 1.6.1
 -----

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ zip_safe = True
 install_requires =
     six >=1.9
     swiglpk >=5.0.8
-    sympy >=1.0
+    sympy >=1.11.1
 python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*
 tests_require =
     tox

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ zip_safe = True
 install_requires =
     six >=1.9
     swiglpk >=5.0.8
-    sympy >=1.11.1
+    sympy >=1.12.0
 python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*
 tests_require =
     tox

--- a/src/optlang/interface.py
+++ b/src/optlang/interface.py
@@ -407,7 +407,6 @@ class OptimizationExpression(object):
         variable_substitutions = dict()
         for variable in expression.variables:
             if model is not None and variable.name in model.variables:
-                # print(variable.name, id(variable.problem))
                 variable_substitutions[variable] = model.variables[variable.name]
             else:
                 variable_substitutions[variable] = interface.Variable.clone(variable)

--- a/src/optlang/scipy_interface.py
+++ b/src/optlang/scipy_interface.py
@@ -243,7 +243,7 @@ class Problem(object):
             index = self._get_constraint_index(name)
             return self._slacks[index]
 
-    def optimize(self, method="simplex", verbosity=False, tolerance=1e-9, **kwargs):
+    def optimize(self, method="highs", verbosity=False, tolerance=1e-9, **kwargs):
         """Run the linprog function on the problem. Returns None."""
         c = np.array([self.objective.get(name, 0) for name in self._variables])
         if self.direction == "max":
@@ -251,7 +251,7 @@ class Problem(object):
 
         bounds = list(six.itervalues(self.bounds))
         solution = linprog(c, self.A, self.upper_bounds, bounds=bounds, method=method,
-                           options={"maxiter": 10000, "disp": verbosity, "tol": tolerance}, **kwargs)
+                           options={"maxiter": 10000, "disp": verbosity}, **kwargs)
         self._solution = solution
         self._status = solution.status
         if SCIPY_STATUS[self._status] == interface.OPTIMAL:

--- a/src/optlang/symbolics.py
+++ b/src/optlang/symbolics.py
@@ -101,8 +101,6 @@ if USE_SYMENGINE:  # pragma: no cover # noqa: C901
 
 else:  # Use sympy
     import sympy
-    from sympy.core.assumptions import _assume_rules
-    from sympy.core.facts import FactKB
 
     optlang._USING_SYMENGINE = False
 
@@ -120,21 +118,14 @@ else:  # Use sympy
     Mul = sympy.Mul
     Pow = sympy.Pow
 
-    class Symbol(sympy.Symbol):
+    class Symbol(sympy.core.Dummy):
         """A generic symbol used in expressions."""
 
-        def __new__(cls, name, **kwargs):
+        def __new__(cls, name, *args, **kwargs):
             if not isinstance(name, six.string_types):
                 raise TypeError("name should be a string, not %s" % repr(type(name)))
 
-            obj = sympy.Symbol.__new__(cls, str(uuid.uuid1()))
-
-            obj.name = name
-            obj._assumptions = FactKB(_assume_rules)
-            obj._assumptions._tell("commutative", True)
-            obj._assumptions._tell("uuid", uuid.uuid1())
-
-            return obj
+            return sympy.core.Dummy.__new__(cls, name)
 
         def __init__(self, *args, **kwargs):
             super(Symbol, self).__init__()

--- a/src/optlang/tests/test_io.py
+++ b/src/optlang/tests/test_io.py
@@ -17,7 +17,6 @@ bound_schema = {
 }
 
 variable_schema = {
-    "$schema": "variable",
     "type": "object",
     "properties": {
         "name": {

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,12 @@
 [tox]
-envlist = isort, black, flake8, safety, docs, py3{7,8,9,10}-symengine
+envlist = isort, black, flake8, safety, docs, py3{8,9,10,11}, py3{8,9,10,11}-symengine
 
 [gh-actions]
 python =
-     3.7: safety, py37, py37-symengine
      3.8: safety, py38, py38-symengine
      3.9: safety, py39, py39-symengine
      3.10: safety, py310, py310-symengine
+     3.11: safety, py311, py311-symengine
 
 ;[testenv]
 ;deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = isort, black, flake8, safety, docs, py3{8,9,10,11}, py3{8,9,10,11}-symengine
+envlist = isort, black, flake8, safety, docs, py3{8,9,10}, py3{8,9,10}-symengine
 
 [gh-actions]
 python =


### PR DESCRIPTION
* [X] fix broken optlang and copbrapy when using sympy==1.12
* [X] description of feature/fix
* [X] tests added/passed
* [x] add an entry to the [next release](../CHANGELOG.rst)

Some changes in sympy 1.12 broke the previous hack in place to make the optlang `Symbol` class unique. However, sympy now has the `Dummy` class for a Symbol where symbols with the same name are unique, so we now derive from that class. Symengine `Symbols` are unique by default, so no changes here.

Also fixes some warnings due to updates in jsonschema and scipy.
