### PR TITLE
Add MIP check in gurobi interface and update shadow_prices and reduced_cost to throw proper error if MIP 

### DIFF
--- a/src/optlang/gurobi_interface.py
+++ b/src/optlang/gurobi_interface.py
@@ -777,6 +777,9 @@ class Model(interface.Model):
         if self.is_integer:
             raise ValueError(
                 "Reduced costs are not well defined for integer problems.")
+        if self.is_mip:
+            raise ValueError(
+                "Reduced costs are not well defined for mixed integer problems. Try relaxing your model first.")
         return self.problem.RC
 
     def _get_shadow_prices(self):
@@ -789,12 +792,20 @@ class Model(interface.Model):
         if self.is_integer:
             raise ValueError(
                 "Shadow prices are not well defined for integer problems.")
+        if self.is_mip:
+            raise ValueError(
+                "Shadow prices are not well defined for mixed integer problems. Try relaxing your model first.")
         return self.problem.Pi
 
     @property
     def is_integer(self):
         self.problem.update()
         return self.problem.NumIntVars > 0
+
+    @property
+    def is_mip(self):
+        self.problem.update()
+        return self.problem.IsMIP == 1
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Because MIPs lose convexity, shadow prices and reduced costs aren't available for them until the model was relaxed (variables transformed and general constraints removed) or fixed (fixes integer values to the best solution found). That means that it is necessary for the functions `_get_reduced_costs` and `_get_shadow_prices` to not only check if the problem is a pure integer problem but also if the model is a mixed integer problem. For that, another property `is_mip` was introduced.

* [x] fix #258
* [x] description of feature/fix
* [x] tests added/passed
* [ ] add an entry to the [next release](../CHANGELOG.rst)
