### PR TITLE
Avoid using the M1 runners on Mac actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-13, windows-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:


### PR DESCRIPTION
* [X] fix failing CI
* [X] description of feature/fix

Hotfix to make the CI work again. Mac latest now defaults to M1 chips.
