### PR TITLE
Upgrade GitHub workflows

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -1,0 +1,11 @@
+name: Cron Test
+
+on:
+  schedule:
+  # Run every Tuesday at 10:30.
+  - cron: '30 10 * * 2'
+
+jobs:
+  prerequisites:
+    uses: ./.github/workflows/test.yml
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,87 +1,15 @@
-name: CI-CD
+name: CI
 
 on:
   push:
     branches:
     - master
     - devel
-    tags:
-    - '[0-9]+.[0-9]+.[0-9]+'
-    - '[0-9]+.[0-9]+.[0-9]+rc[0-9]+'
   pull_request:
     branches:
     - master
     - devel
 
 jobs:
-  test:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-13, windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip setuptools wheel
-        python -m pip install tox tox-gh-actions
-    - name: Test with tox
-      run: tox -- --cover-xml
-      env:
-        CI: true
-    - name: Report coverage
-      shell: bash
-      run: bash <(curl -s https://codecov.io/bash)
-
-  release:
-    needs: test
-    if: startsWith(github.ref, 'refs/tags')
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        python-version: [3.8]
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Get tag
-      id: tag
-      run: echo "::set-output name=version::${GITHUB_REF#refs/tags/}"
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip setuptools wheel
-        python -m pip install twine
-    - name: Build package
-      run: python setup.py sdist bdist_wheel
-    - name: Check the package
-      run: twine check dist/*
-    - name: Publish to PyPI
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      run:
-        twine upload --skip-existing --non-interactive dist/*
-    - name: Create GitHub release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ github.ref }}
-        release_name: ${{ github.ref }}
-        body: >
-          Please see
-          https://github.com/${{ github.repository }}/blob/${{ steps.tag.outputs.version }}/CHANGELOG.rst
-          for the full release notes.
-        draft: false
-        prerelease: false
+  prerequisites:
+    uses: ./.github/workflows/test.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.12"]
+        python-version: ["3.11"]
     runs-on: ${{ matrix.os }}
     permissions:
       # Write permissions are needed to create OIDC tokens.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,56 @@
+name: CD
+
+on:
+  push:
+    tags:
+    - '[0-9]+.[0-9]+.[0-9]+'
+    - '[0-9]+.[0-9]+.[0-9]+(a|b|rc|post|dev)[0-9]+'
+
+jobs:
+  prerequisites:
+    uses: ./.github/workflows/test.yml
+
+  release:
+    needs: [prerequisites]
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.12"]
+    runs-on: ${{ matrix.os }}
+    permissions:
+      # Write permissions are needed to create OIDC tokens.
+      id-token: write
+      # Write permissions are needed to make GitHub releases.
+      contents: write
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install build
+
+    - name: Build package
+      run: python -m build
+
+    # We rely on a trusted publisher configuration being present on PyPI,
+    # see https://docs.pypi.org/trusted-publishers/.
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+
+    - name: GH release
+      uses: softprops/action-gh-release@v2
+      with:
+        body: >
+          Please see
+          https://github.com/${{ github.repository }}/blob/${{ github.ref_name }}/CHANGELOG.rst
+          for the full release notes.
+        draft: false
+        prerelease: false
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,43 @@
+name: Test Suite
+
+on:
+  workflow_dispatch: {}
+  workflow_call: {}
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-13, windows-latest]
+        python-version: ["3.8", "3.12"]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install build tox tox-gh-actions twine
+
+    - name: Build package
+      run: python -m build
+
+    - name: Check the package distribution
+      run: twine check dist/*
+
+    - name: Test with tox
+      run: tox -- --cover-xml
+      env:
+        CI: true
+
+    - name: Report coverage
+      shell: bash
+      run: bash <(curl -s https://codecov.io/bash)
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-13, windows-latest]
-        python-version: ["3.8", "3.12"]
+        python-version: ["3.8", "3.11"]
 
     steps:
     - uses: actions/checkout@v4

--- a/README.rst
+++ b/README.rst
@@ -150,8 +150,8 @@ Future outlook
 .. |Code of Conduct| image:: https://img.shields.io/badge/Contributor%20Covenant-v2.0%20adopted-ff69b4.svg
    :target: .github/CODE_OF_CONDUCT.md
    :alt: Code of Conduct
-.. |GitHub Actions| image:: https://github.com/opencobra/optlang/workflows/CI-CD/badge.svg
-   :target: https://github.com/opencobra/optlang/workflows/CI-CD
+.. |GitHub Actions| image:: https://github.com/opencobra/optlang/actions/workflows/main.yml/badge.svg
+   :target: https://github.com/opencobra/optlang/actions/workflows/main.yml
    :alt: GitHub Actions
 .. |Coverage Status| image:: https://codecov.io/gh/opencobra/optlang/branch/master/graph/badge.svg
    :target: https://codecov.io/gh/opencobra/optlang

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,6 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Natural Language :: English
     Operating System :: OS Independent
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10


### PR DESCRIPTION
Upgrade the GitHub workflows in the following ways:

* Create a reusable test workflow
* Run tests on push and PR
* Run release on pushed tags
* Run a weekly test job, so we can notice problems sooner
* Rely on OIDC tokens for publishing to PyPI