### PR TITLE
Fix test for objective offset

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,10 @@
 Next Release
 -----
 
+1.8.3
+-----
+* fix the objective offset test for compatibility with Debian sid
+
 1.8.2
 -----
 * fix the feasibility check in the hybrid solver

--- a/src/optlang/tests/abstract_test_cases.py
+++ b/src/optlang/tests/abstract_test_cases.py
@@ -824,7 +824,8 @@ class AbstractModelTestCase(unittest.TestCase, metaclass=abc.ABCMeta):
         self.model.objective = self.interface.Objective(objective.expression + 3)
         self.model.update()
         self.assertEqual(
-            (self.model.objective.expression - (objective.expression + 3.)).expand().evalf(),
+            float((self.model.objective.expression -
+                  (objective.expression + 3.)).expand().evalf()),
             0.
         )
 

--- a/src/optlang/tests/abstract_test_cases.py
+++ b/src/optlang/tests/abstract_test_cases.py
@@ -823,7 +823,10 @@ class AbstractModelTestCase(unittest.TestCase, metaclass=abc.ABCMeta):
         objective = self.model.objective
         self.model.objective = self.interface.Objective(objective.expression + 3)
         self.model.update()
-        self.assertEqual((self.model.objective.expression - (objective.expression + 3.)).expand(), 0.)
+        self.assertEqual(
+            (self.model.objective.expression - (objective.expression + 3.)).expand().evalf(),
+            0.
+        )
 
     def test_is_integer(self):
         model = self.model

--- a/src/optlang/tests/test_hybrid_interface.py
+++ b/src/optlang/tests/test_hybrid_interface.py
@@ -324,7 +324,11 @@ else:
             self.assertEqual(constraint.name, "test")
             self.assertEqual(constraint.lb, -100)
             self.assertEqual(constraint.ub, None)
-            self.assertEqual((constraint.expression - (0.4 * y + 0.3 * x + 77.0 * z)).expand(), 0.0)
+            self.assertEqual(
+                float((constraint.expression -
+                       (0.4 * y + 0.3 * x + 77.0 * z)).expand().evalf()),
+                0.0
+            )
 
         def test_change_of_objective_is_reflected_in_low_level_solver(self):
             x = Variable('x', lb=-83.3, ub=1324422.)


### PR DESCRIPTION
* [X] fix #268 
* [X] description of feature/fix
* [X] tests added/passed
* [X] add an entry to the [next release](../CHANGELOG.rst)

This fixes #268. I opted for the expand->evalf because it works with sympy and symengine without adding new sympy imports (because the plan is to drop the hard sympy req in the future).

Also fixed another instance of this in the hybrid solver tests.