### PR TITLE
Make optlang compatible with Gurobi 12.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Next Release
 1.8.3
 -----
 * fix the objective offset test for compatibility with Debian sid
+* enable compatibility with Gurobi 12.0
 
 1.8.2
 -----

--- a/src/optlang/gurobi_interface.py
+++ b/src/optlang/gurobi_interface.py
@@ -286,7 +286,7 @@ class Constraint(interface.Constraint, metaclass=inheritdocstring):
                 updated_row = row - aux_var
                 self.problem.problem.remove(gurobi_constraint)
                 self.problem.problem.update()
-                self.problem.problem.addConstr(updated_row, sense, rhs, self.name)
+                self.problem.problem.addLConstr(updated_row, sense, rhs, self.name)
             aux_var.setAttr("UB", range_value)
         self.problem.update()
 
@@ -720,7 +720,7 @@ class Model(interface.Model):
                     self.problem.update()
                     lhs = lhs - aux_var
 
-                self.problem.addConstr(lhs, sense, rhs, name=constraint.name)
+                self.problem.addLConstr(lhs, sense, rhs, name=constraint.name)
             else:
                 raise ValueError(
                     "GUROBI currently only supports linear constraints. %s is not linear." % self)


### PR DESCRIPTION
* [X] fix #273
* [X] description of feature/fix
* [X] tests added/passed
* [X] add an entry to the [next release](../CHANGELOG.rst)

This is a simple fix to enable compatibility with Gurobi 12.0. The change is backwards compatible to prior Gurobi versions.