### PR TITLE
Enable Python 3.13 and make tests more resilient to lacking cplex/gurobi wheels

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.11"]
+        python-version: ["3.13"]
     runs-on: ${{ matrix.os }}
     permissions:
       # Write permissions are needed to create OIDC tokens.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-13, windows-latest]
-        python-version: ["3.8", "3.11"]
+        python-version: ["3.9", "3.11", "3.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ Next Release
 * enable compatibility with Gurobi 12.0
 * fix an issue where the removal of more than 350 constraints
   would lead to dangling references
+* add support for Python 3.13
 
 1.8.2
 -----

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,10 +15,11 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Natural Language :: English
     Operating System :: OS Independent
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Topic :: Scientific/Engineering :: Mathematics
 license = Apache-2.0
 description = Formulate optimization problems using sympy expressions and solve them using interfaces to third-party optimization software (e.g. GLPK).
@@ -33,9 +34,9 @@ keywords =
 [options]
 zip_safe = True
 install_requires =
-    swiglpk >=5.0.8
+    swiglpk >=5.0.12
     sympy >=1.12.0
-python_requires = >=3.8
+python_requires = >=3.9
 tests_require =
     tox
 packages = find:

--- a/src/optlang/tests/test_container.py
+++ b/src/optlang/tests/test_container.py
@@ -48,7 +48,7 @@ class ContainerTestCase(unittest.TestCase):
         self.container.append(var)
         print(dir(self.container))
         self.assertTrue(
-            all(attribute in dir(self.container)
+            all(hasattr(self.container, attribute)
                 for attribute in ['__contains__', 'keys', 'values'])
         )
 

--- a/src/optlang/tests/test_container.py
+++ b/src/optlang/tests/test_container.py
@@ -47,12 +47,10 @@ class ContainerTestCase(unittest.TestCase):
         var = Variable('blub')
         self.container.append(var)
         print(dir(self.container))
-        self.assertEqual(dir(self.container),
-                         ['__contains__', '__delitem__', '__dict__', '__dir__', '__doc__', '__getattr__', '__getitem__',
-                          '__getstate__', '__init__', '__iter__', '__len__', '__module__', '__setitem__',
-                          '__setstate__', '__weakref__', '_check_for_name_attribute', '_reindex', 'append', 'blub',
-                          'clear', 'extend', 'fromkeys', 'get', 'has_key', 'items', 'iteritems', 'iterkeys',
-                          'itervalues', 'keys', 'update_key', 'values'])
+        self.assertTrue(
+            all(attribute in dir(self.container)
+                for attribute in ['__contains__', 'keys', 'values'])
+        )
 
     def test_del_by_index(self):
         variables_iterable = [Variable("v" + str(i), lb=10, ub=100) for i in range(1000)]

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,7 @@ deps =
      jsonschema
      pytest
      pytest-cov
-     scipy <=1.14  # until https://github.com/scipy/scipy/issues/22257 is fixed
+     scipy <1.15.0  # until https://github.com/scipy/scipy/issues/22257 is fixed
      numpy >=1.13
      osqp >=0.6.2
      mip >=1.9.1; python_version < "3.13"

--- a/tox.ini
+++ b/tox.ini
@@ -36,9 +36,7 @@ deps =
      osqp >=0.6.2
      mip >=1.9.1
      highspy >=1.5.3
-     solvers:
-          cplex
-          gurobipy
+     solvers: cplex, gurobipy
      symengine: symengine
 passenv = CI
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ envlist =
 [gh-actions]
 python =
      3.9: safety, py39, py39-symengine
-     3.11: safety, py311, py311-symengine, py311-solvers
+     3.11: safety, py311, py311-symengine
      3.13: safety, py313, py313-symengine
 
 ;[testenv]
@@ -34,10 +34,10 @@ deps =
      scipy
      numpy >=1.13
      osqp >=0.6.2
-     mip >=1.9.1
+     mip >=1.9.1; python_version < "3.13"
      highspy >=1.5.3
-     solvers: cplex
-     solvers: gurobipy
+     cplex; python_version < "3.12"
+     gurobipy; python_version < "3.13"
      symengine: symengine
 passenv = CI
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,19 @@
 [tox]
-envlist = isort, black, flake8, safety, docs, py3{8,9,10,11}, py3{8,9,10,11}-symengine
+envlist =
+     isort
+     black
+     flake8
+     safety
+     docs
+     py3{9,11,13}
+     py3{9,11,13}-symengine
+     py311-solvers
 
 [gh-actions]
 python =
-     3.8: safety, py38, py38-symengine
      3.9: safety, py39, py39-symengine
-     3.10: safety, py310, py310-symengine
-     3.11: safety, py311, py311-symengine
+     3.11: safety, py311, py311-symengine, py311-solvers
+     3.13: safety, py313, py313-symengine
 
 ;[testenv]
 ;deps =
@@ -25,12 +32,13 @@ deps =
      pytest
      pytest-cov
      scipy
-     numpy >=1.13,<1.24
+     numpy >=1.13
      osqp >=0.6.2
      mip >=1.9.1
      highspy >=1.5.3
-     cplex
-     gurobipy
+     solvers:
+          cplex
+          gurobipy
      symengine: symengine
 passenv = CI
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,8 @@ deps =
      osqp >=0.6.2
      mip >=1.9.1
      highspy >=1.5.3
-     solvers: cplex, gurobipy
+     solvers: cplex
+     solvers: gurobipy
      symengine: symengine
 passenv = CI
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,6 @@ envlist =
      docs
      py3{9,11,13}
      py3{9,11,13}-symengine
-     py311-solvers
 
 [gh-actions]
 python =

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,7 @@ deps =
      jsonschema
      pytest
      pytest-cov
-     scipy
+     scipy <=1.14  # until https://github.com/scipy/scipy/issues/22257 is fixed
      numpy >=1.13
      osqp >=0.6.2
      mip >=1.9.1; python_version < "3.13"


### PR DESCRIPTION
* [X] description of feature/fix
* [X] tests added/passed
* [X] add an entry to the [next release](../CHANGELOG.rst)

This updates the CI/CD to newer Python versions and limits the CPLEX, Gurobi, and MIP tests to those python versions that support them.